### PR TITLE
CI/flake lock updater

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -21,6 +21,21 @@ jobs:
       - name: Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@main
 
+      - name: Start ssh-agent and add deploy read-only key (private flake inputs)
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.CI_GITHUB_SSH_KEY }}
+
+      - name: Add GitHub to known_hosts
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Force git to use known_hosts
+        run: |
+          echo "GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts" >> "$GITHUB_ENV"
+
       - name: Update flake.lock (create PR)
         id: update
         uses: DeterminateSystems/update-flake-lock@v28

--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -1,0 +1,45 @@
+name: Update flake.lock
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 7 * * 0"
+
+jobs:
+  update-flake-lock:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+
+      - name: Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Update flake.lock (create PR)
+        id: update
+        uses: DeterminateSystems/update-flake-lock@v28
+        with:
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+
+          pr-title: "flake: system updates ({date:%d/%m/%y})"
+          pr-labels: |
+            dependencies
+            automated
+
+          sign-commits: true
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      # Enable auto-merge for the PR that was just created/updated
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          pull-request-number: ${{ steps.update.outputs.pull-request-number }}
+          merge-method: rebase


### PR DESCRIPTION
New CI implementation that:

- Uses update-flake-lock from Determinate Systems to update all inputs for the repos flake.lock file
- Loads in a read-only SSH key to enable the nix-secrets input to update without prejudice
- Auto-runs every Sunday at 7am UTC
- Raises a PR following the same commit name convention as my manual flake.lock pushes
- Ensures the raised PR will be marked for auto merge (assuming it passes all Nix CI check)
- Does away with the nvd diff output I have for local flake updates; I cant work out a way to easily/cheaply replicate that in CI.