### PR TITLE
flake(outputs): global vars update

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,8 @@
     let
       vars = rec {
         username = "rickie";
-        nixos-config = "/home/${username}/nixos-config";
+        nixos-path = "/home/${username}/nixos-config";
+        flakeSource = self;
         secretsPath = builtins.toString inputs.nix-secrets;
         syncthingPath = "/home/${username}/Sync";
       };

--- a/home/modules/applications/hypr/hyprland.nix
+++ b/home/modules/applications/hypr/hyprland.nix
@@ -11,6 +11,7 @@ let
   scripts = rec {
     undim_screen = import ./scripts/undim_screen.nix { inherit pkgs; };
   };
+  hyprConfig = vars.flakeSource + "/hosts/${hostname}/applications/hypr/hyprland.conf";
 in
 {
   options = with lib; {
@@ -28,6 +29,8 @@ in
     with lib;
     mkIf config.applications.hypr.enable {
       # Shared hyprland configuration
+
+      xdg.configFile."hypr/${hostname}.conf".source = hyprConfig;
 
       wayland.windowManager.hyprland = {
         enable = true;
@@ -138,8 +141,8 @@ in
           $WS9 = 9-ext2
           $WS0 = 10-ext3
 
-          $HYPRLAND_CONFIG_PATH = /home/${vars.username}/.config/hypr
-          source = ${vars.nixos-config}/hosts/${hostname}/applications/hypr/hyprland.conf
+          $HYPRLAND_CONFIG_PATH = ${config.xdg.configHome}/hypr
+          source = $HYPRLAND_CONFIG_PATH/${hostname}.conf
         '';
       };
     };

--- a/home/modules/applications/waybar/default.nix
+++ b/home/modules/applications/waybar/default.nix
@@ -11,6 +11,7 @@ let
     waybar = import ./scripts { inherit pkgs; };
     scroll_mpris = import ./scripts/scroll-mpris { inherit pkgs; };
   };
+  waybarConfig = vars.flakeSource + "/hosts/${hostname}/applications/waybar/waybar.conf";
 in
 {
   options = with lib; {
@@ -33,7 +34,7 @@ in
               mainBar = {
                 "layer" = "top";
                 "position" = "top";
-                "includes" = [ "${vars.nixos-config}/hosts/${hostname}/applications/waybar/waybar.conf" ];
+                "includes" = [ waybarConfig ];
                 "height" = 40;
 
                 "modules-left" = [ "hyprland/workspaces" ];

--- a/home/modules/scripts/nix/default.nix
+++ b/home/modules/scripts/nix/default.nix
@@ -11,8 +11,7 @@
       gnused
     ];
     text = ''
-      CONFIG="${vars.nixos-config}"
-      HOME="/home/${vars.username}"
+      CONFIG="${vars.nixos-path}"
       OUTFILE="$HOME/changes_$(date +%d-%m-%y).out"
       cd $CONFIG
       echo "Beginning build. This may take some time."

--- a/home/users/rickie/gibson.nix
+++ b/home/users/rickie/gibson.nix
@@ -106,7 +106,7 @@
         cpu_usage = "ps -eo pid,ppid,%mem,%cpu,cmd --sort=-%cpu | head";
         mem_usage = "ps -eo pid,ppid,%mem,%cpu,cmd --sort=-%mem | head";
         shred = "shred -zfu";
-        nixos-rebuild = "systemd-inhibit --no-pager --no-legend --mode=block --who='${vars.username}' --why='NixOS Upgrades' sudo nixos-rebuild --flake ${vars.nixos-config} $@ --option eval-cache false --show-trace";
+        nixos-rebuild = "systemd-inhibit --no-pager --no-legend --mode=block --who='${vars.username}' --why='NixOS Upgrades' sudo nixos-rebuild --flake ${vars.nixos-path} $@ --option eval-cache false --show-trace";
         spicy = "spicy --spice-ca-file=/etc/pki/libvirt-spice/ca-cert.pem --uri 'spice://127.0.0.1' -p 5900 -s 5901 --title 'th3h4x0r' -f > /dev/null 2>&1 &|";
         pass = "pass -c main";
       };


### PR DESCRIPTION
- `vars.nixos-config` has been renamed to `vars.nixos-path`
- Relevant files have been updated to reflect this var name change
- A new var named `flakeSource` has been created
- Hyprland config is now source via `vars.flakeSource`
- HM's XDG module is now used to include Hyprland config
- Waybar config is also now sourced via `vars.flakeSource`