### PR TITLE
refactor(vars): removal of nixos-path from flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,6 @@
     let
       vars = rec {
         username = "rickie";
-        nixos-path = "/home/${username}/nixos-config";
         flakeSource = self;
         secretsPath = builtins.toString inputs.nix-secrets;
         syncthingPath = "/home/${username}/Sync";

--- a/home/modules/applications/doomemacs/doom/config.el
+++ b/home/modules/applications/doomemacs/doom/config.el
@@ -98,8 +98,19 @@
 (setq lsp-nix-nixd-server-path "nixd"
       lsp-nix-nixd-formatting-command [ "nixfmt" ]
       lsp-nix-nixd-nixpkgs-expr "import <nixpkgs> { }"
-      lsp-nix-nixd-nixos-options-expr "(builtins.getFlake \"/home/rickie/nixos-config\").nixosConfigurations.gibson.options"
-      lsp-nix-nixd-home-manager-options-expr "(builtins.getFlake \"/home/rickie/nixos-config\").homeConfigurations.\"rickie@gibson\".options"))
+
+      ;; Use $NIXOS_CONFIG when available so Linux and macOS both work.
+      lsp-nix-nixd-nixos-options-expr
+      (let* ((repo (or (getenv "NIXOS_CONFIG")
+                       (expand-file-name "~/nixos-config")))
+             (flake (format "(builtins.getFlake \"%s\")" repo)))
+        (format "%s.nixosConfigurations.gibson.options" flake))
+
+      lsp-nix-nixd-home-manager-options-expr
+      (let* ((repo (or (getenv "NIXOS_CONFIG")
+                       (expand-file-name "~/nixos-config")))
+             (flake (format "(builtins.getFlake \"%s\")" repo)))
+        (format "%s.nixosConfigurations.gibson.config.home-manager.users.rickie.home.options" flake)))
 
 (add-hook! 'nix-mode-hook
          ;; enable autocompletion with company

--- a/home/modules/scripts/nix/default.nix
+++ b/home/modules/scripts/nix/default.nix
@@ -11,22 +11,22 @@
       gnused
     ];
     text = ''
-      CONFIG="${vars.nixos-path}"
+      CONFIG="''${NIXOS_CONFIG:-$HOME/nixos-config}"
       OUTFILE="$HOME/changes_$(date +%d-%m-%y).out"
-      cd $CONFIG
+      cd "$CONFIG"
       echo "Beginning build. This may take some time."
       echo ""
-      systemd-inhibit --no-pager --no-legend --mode=block --who='${vars.username}' --why='NixOS System Building' nixos-rebuild --flake $CONFIG build --option eval-cache false --show-trace
+      systemd-inhibit --no-pager --no-legend --mode=block --who='${vars.username}' --why='NixOS System Building' nixos-rebuild --flake "$CONFIG" build --option eval-cache false --show-trace
 
       echo ""
       echo "Build complete. Providing result:"
       echo ""
-      nvd diff /run/current-system $CONFIG/result > "$OUTFILE"
+      nvd diff /run/current-system "$CONFIG"/result > "$OUTFILE"
 
       #Cleanup
       awk -i inplace '{$0=gensub(/\s*\S+/,"",2)}1' "$OUTFILE"
       sed -i -e '1,2d' -e 's/Version/Changed\/Updated:/g' -e 's/Added/\nAdded:/g' -e 's/Removed/\nRemoved:/g' -e '$d' "$OUTFILE"
-      rm $CONFIG/result
+      rm "$CONFIG"/result
 
       cat "$OUTFILE"
 

--- a/home/users/rickie/common.nix
+++ b/home/users/rickie/common.nix
@@ -19,6 +19,7 @@ in
 
     sessionVariables = {
       GIT_AUTO_FETCH_INTERVAL = 1200;
+      NIXOS_CONFIG = "${config.home.homeDirectory}/nixos-config";
     };
 
     packages = with pkgs; [

--- a/home/users/rickie/gibson.nix
+++ b/home/users/rickie/gibson.nix
@@ -104,7 +104,7 @@
         cpu_usage = "ps -eo pid,ppid,%mem,%cpu,cmd --sort=-%cpu | head";
         mem_usage = "ps -eo pid,ppid,%mem,%cpu,cmd --sort=-%mem | head";
         shred = "shred -zfu";
-        nixos-rebuild = "systemd-inhibit --no-pager --no-legend --mode=block --who='${vars.username}' --why='NixOS Upgrades' sudo nixos-rebuild --flake ${vars.nixos-path} $@ --option eval-cache false --show-trace";
+        nixos-rebuild = "systemd-inhibit --no-pager --no-legend --mode=block --who='${vars.username}' --why='NixOS Upgrades' sudo nixos-rebuild --flake $NIXOS_CONFIG:-$HOME/nixos-config}#gibson $@ --option eval-cache false --show-trace";
         spicy = "spicy --spice-ca-file=/etc/pki/libvirt-spice/ca-cert.pem --uri 'spice://127.0.0.1' -p 5900 -s 5901 --title 'th3h4x0r' -f > /dev/null 2>&1 &|";
         pass = "pass -c main";
       };


### PR DESCRIPTION
- This is now an env var defined in common.nix
- Updated all doom/scripts/shell aliases that use this var