### PR TITLE
flake(inputs): added a nixpksgs input for darwin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -198,6 +198,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-darwin": {
+      "locked": {
+        "lastModified": 1769237874,
+        "narHash": "sha256-saOixpqPT4fiE/M8EfHv9I98f3sSEvt6nhMJ/z0a7xI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "523257564973361cc3e55e3df3e77e68c20b0b80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1765674936,
@@ -383,6 +399,7 @@
         "nix-secrets": "nix-secrets",
         "nixos-xivlauncher-rb": "nixos-xivlauncher-rb",
         "nixpkgs": "nixpkgs_4",
+        "nixpkgs-darwin": "nixpkgs-darwin",
         "nixpkgs-old": "nixpkgs-old",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "qute-dracula": "qute-dracula",

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,10 @@
       url = "github:nixos/nixpkgs/nixos-25.05";
     };
 
+    nixpkgs-darwin = {
+      url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    };
+
     # Other Stuff
     emacs-overlay = {
       url = "github:nix-community/emacs-overlay/master";
@@ -90,8 +94,13 @@
             inherit system;
             config.allowUnfree = true;
           };
+          pkgs-darwin = import nixpkgs-darwin {
+            inherit system;
+            config.allowUnfree = true;
+          };
         };
     in
+
     {
       nixosConfigurations = with inputs; {
         # Main Machine (Gibson)
@@ -143,7 +152,7 @@
           system = "aarch64-darwin";
           specialArgs = {
             hostname = "macbook";
-            inherit (pkgsFor "${system}") pkgs-stable;
+            inherit (pkgsFor "${system}") pkgs-darwin;
             inherit inputs system vars;
           };
 


### PR DESCRIPTION
- Currently MacOS uses the same pkgs branch as my main NixOS system
- This adds a new input based on nixpkgs-unstable called nixpkgs-darwin
- It also aligns with the correct, expected non-nixOS pkg management paradigm
- Mac has been tested before merge.