### PR TITLE
container(pentesting): x11 exposure + tmux

### DIFF
--- a/nixosModules/containers/pentesting/default.nix
+++ b/nixosModules/containers/pentesting/default.nix
@@ -26,6 +26,12 @@ in
         isReadOnly = true;
       };
 
+      # X11 socket, for specific apps, e.g. burp
+      "/tmp/.X11-unix" = {
+        hostPath = "/tmp/.X11-unix";
+        isReadOnly = true;
+      };
+
       # Optional, give the container a scratch workspace on the host
       "/home/${hostUser}/HTB" = {
         hostPath = "/home/${vars.username}/Sync/Cyber/Platforms/HTB";
@@ -71,6 +77,7 @@ in
           sessionVariables = {
             XDG_RUNTIME_DIR = "/run/user/1000";
             WAYLAND_DISPLAY = "/run/wayland/wayland-1";
+            DISPLAY = ":0";
             QT_QPA_PLATFORM = "wayland";
             MOZ_ENABLE_WAYLAND = "1";
             TERM = "xterm";
@@ -104,6 +111,7 @@ in
           openvpn
           python3
           python3Packages.pip
+          tmux
           vim
 
           nmap


### PR DESCRIPTION
- Passed in the xwayland socket for certain apps (burp..)
- Added in the tmux package