### PR TITLE
flake(outputs): added in default/common HM outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -191,5 +191,10 @@
           ]; # End modules
         }; # End macbook
       }; # End darwinConfigurations
+
+      homeManagerModules = {
+        default = import ./home/modules;
+        commonConfig = import ./home/user/common.nix;
+      };
     };
 }

--- a/hosts/gibson/home.nix
+++ b/hosts/gibson/home.nix
@@ -6,9 +6,9 @@
 }:
 {
   imports = [
-    ../../home/modules
-    ../../home/user/common.nix
     ../../home/user/gibson.nix
     inputs.wayland-pipewire-idle-inhibit.homeModules.default
+    inputs.self.homeManagerModules.default
+    inputs.self.homeManagerModules.commonConfig
   ];
 }

--- a/hosts/macbook/home.nix
+++ b/hosts/macbook/home.nix
@@ -1,12 +1,13 @@
 {
   config,
   lib,
+  inputs,
   ...
 }:
 {
   imports = [
-    ../../home/modules
-    ../../home/user/common.nix
     ../../home/user/macbook.nix
+    inputs.self.homeManagerModules.default
+    inputs.self.homeManagerModules.commonConfig
   ];
 }


### PR DESCRIPTION
- Rather than import via path in each host config an input is now used
- This makes folder changes etc easier going forward and allows for external use
- Host config has also been updated appropriately