### PR TITLE
security(fix): update bytes crate

### DIFF
--- a/home/modules/applications/waybar/scripts/scroll-mpris/Cargo.lock
+++ b/home/modules/applications/waybar/scripts/scroll-mpris/Cargo.lock
@@ -98,9 +98,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"

--- a/home/modules/applications/waybar/scripts/scroll-mpris/default.nix
+++ b/home/modules/applications/waybar/scripts/scroll-mpris/default.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage {
     rev = "3e393327eff442ac74b4babbecc84dc2da82b2b6";
     sha256 = "sha256-KWEKD5NmeMih/GPqYsx+Mn5aUTJarSqR6pp9/IYdF4Y=";
   };
-  cargoHash = "sha256-2KhyUoz7G637jXDFSXAgLJP6FGW9dJMzYMi41aaiqaU=";
+  cargoHash = "sha256-Hs+lGesdwkQuQwQKKtwDIg4BH8iqYXS7m4izaV6SZUA=";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dbus ];
   patches = [


### PR DESCRIPTION
- Included with ScrollMPRIS, used by Waybar
- Fixes GHSA-434x-w66g-qw3r