### PR TITLE
container(pentesting): disable firewall

### DIFF
--- a/nixosModules/containers/pentesting/default.nix
+++ b/nixosModules/containers/pentesting/default.nix
@@ -136,7 +136,7 @@ in
           wireshark
         ];
 
-        networking.firewall.enable = true;
+        networking.firewall.enable = false;
 
         services.openssh.enable = true;
         services.openssh.settings = {


### PR DESCRIPTION
- Mainly to prevent the blocking of reverse shells from lab VMs