### PR TITLE
refactor(flake): initial adoption of flake-parts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,6 +41,24 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
         "lastModified": 1768135262,
         "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
@@ -54,9 +72,9 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
+    "flake-parts_3": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
+        "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
         "lastModified": 1768135262,
@@ -92,20 +110,6 @@
         "type": "github"
       }
     },
-    "hyprddm": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "path": "./flakes/sddm-themes",
-        "type": "path"
-      },
-      "original": {
-        "path": "./flakes/sddm-themes",
-        "type": "path"
-      },
-      "parent": []
-    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -128,8 +132,8 @@
     },
     "nix-gaming": {
       "inputs": {
-        "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_3"
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1769914377,
@@ -216,6 +220,21 @@
     },
     "nixpkgs-lib": {
       "locked": {
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
         "lastModified": 1765674936,
         "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
@@ -229,7 +248,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_2": {
+    "nixpkgs-lib_3": {
       "locked": {
         "lastModified": 1765674936,
         "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
@@ -294,22 +313,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1765472234,
-        "narHash": "sha256-9VvC20PJPsleGMewwcWYKGzDIyjckEz8uWmT0vCDYK0=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "2fbfb1d73d239d2402a8fe03963e37aab15abe8b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1769740369,
         "narHash": "sha256-xKPyJoMoXfXpDM5DFDZDsi9PHArf2k5BJjvReYXoFpM=",
         "owner": "NixOS",
@@ -324,7 +327,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1769461804,
         "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
@@ -335,6 +338,22 @@
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1765472234,
+        "narHash": "sha256-9VvC20PJPsleGMewwcWYKGzDIyjckEz8uWmT0vCDYK0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2fbfb1d73d239d2402a8fe03963e37aab15abe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -392,20 +411,35 @@
       "inputs": {
         "doomemacs": "doomemacs",
         "emacs-overlay": "emacs-overlay",
+        "flake-parts": "flake-parts",
         "home-manager": "home-manager",
-        "hyprddm": "hyprddm",
         "nix-darwin": "nix-darwin",
         "nix-gaming": "nix-gaming",
         "nix-secrets": "nix-secrets",
         "nixos-xivlauncher-rb": "nixos-xivlauncher-rb",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-darwin": "nixpkgs-darwin",
         "nixpkgs-old": "nixpkgs-old",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "qute-dracula": "qute-dracula",
+        "sddm-themes": "sddm-themes",
         "sops-nix": "sops-nix",
         "wayland-pipewire-idle-inhibit": "wayland-pipewire-idle-inhibit"
       }
+    },
+    "sddm-themes": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_4"
+      },
+      "locked": {
+        "path": "./flakes/sddm-themes",
+        "type": "path"
+      },
+      "original": {
+        "path": "./flakes/sddm-themes",
+        "type": "path"
+      },
+      "parent": []
     },
     "sops-nix": {
       "inputs": {
@@ -463,7 +497,7 @@
     },
     "wayland-pipewire-idle-inhibit": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": "nixpkgs_6",
         "systems": "systems",
         "treefmt-nix": "treefmt-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -1,202 +1,55 @@
 {
-  description = "Gibson - NixOS Flake";
+  description = "5ysk3y's Systems Flake";
 
   inputs = {
-    # Official NixOS package source, using nixos-unstable branch here
-    nixpkgs = {
-      url = "github:NixOS/nixpkgs/nixos-unstable";
-    };
+    # nixpkgs repos
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs-old.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs-darwin.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
-    # nixPkgs Stable
-    nixpkgs-stable = {
-      url = "github:nixos/nixpkgs/nixos-25.11";
-    };
+    # nix-darwin
+    nix-darwin.url = "github:LnL7/nix-darwin";
+    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
 
-    nixpkgs-old = {
-      url = "github:nixos/nixpkgs/nixos-25.05";
-    };
+    # home-manager
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
-    nixpkgs-darwin = {
-      url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    };
+    # secrets
+    nix-secrets.url = "git+ssh://git@github.com/5ysk3y/nix-secrets.git?ref=main";
+    nix-secrets.flake = false;
 
-    # Other Stuff
-    emacs-overlay = {
-      url = "github:nix-community/emacs-overlay/master";
-    };
+    # other stuff
+    flake-parts.url = "github:hercules-ci/flake-parts";
 
-    home-manager = {
-      url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    nixos-xivlauncher-rb.url = "github:drakon64/nixos-xivlauncher-rb";
+    nixos-xivlauncher-rb.inputs.nixpkgs.follows = "nixpkgs";
 
-    doomemacs = {
-      url = "github:doomemacs/doomemacs";
-      flake = false;
-    };
+    emacs-overlay.url = "github:nix-community/emacs-overlay/master";
+    sops-nix.url = "github:Mic92/sops-nix";
+    wayland-pipewire-idle-inhibit.url = "github:rafaelrc7/wayland-pipewire-idle-inhibit";
+    nix-gaming.url = "github:fufexan/nix-gaming";
+    sddm-themes.url = "path:./flakes/sddm-themes";
 
-    qute-dracula = {
-      url = "github:dracula/qutebrowser";
-      flake = false;
-    };
+    doomemacs.url = "github:doomemacs/doomemacs";
+    doomemacs.flake = false;
 
-    sops-nix = {
-      url = "github:Mic92/sops-nix";
-    };
-
-    wayland-pipewire-idle-inhibit = {
-      url = "github:rafaelrc7/wayland-pipewire-idle-inhibit";
-    };
-
-    nixos-xivlauncher-rb = {
-      url = "github:drakon64/nixos-xivlauncher-rb";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    nix-gaming = {
-      url = "github:fufexan/nix-gaming";
-    };
-
-    hyprddm = {
-      url = "path:./flakes/sddm-themes";
-    };
-
-    # Darwin/Mac
-    nix-darwin = {
-      url = "github:LnL7/nix-darwin";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    # Secrets
-    nix-secrets = {
-      url = "git+ssh://git@github.com/5ysk3y/nix-secrets.git?ref=main";
-      flake = false;
-    };
+    qute-dracula.url = "github:dracula/qutebrowser";
+    qute-dracula.flake = false;
   };
 
   outputs =
-    { self, ... }@inputs:
-    let
-      vars = rec {
-        username = "rickie";
-        flakeSource = self;
-        secretsPath = builtins.toString inputs.nix-secrets;
-        syncthingPath = "/home/${username}/Sync";
-      };
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
 
-      pkgsFor =
-        system: with inputs; {
-          pkgs-stable = import nixpkgs-stable {
-            inherit system;
-            config.allowUnfree = true;
-          };
-          pkgs-old = import nixpkgs-old {
-            inherit system;
-            config.allowUnfree = true;
-          };
-          pkgs-darwin = import nixpkgs-darwin {
-            inherit system;
-            config.allowUnfree = true;
-          };
-        };
-    in
-
-    {
-      nixosConfigurations = with inputs; {
-        # Main Machine (Gibson)
-        "gibson" = nixpkgs.lib.nixosSystem rec {
-          system = "x86_64-linux";
-          specialArgs = {
-            hostname = "gibson";
-            inherit (pkgsFor "${system}") pkgs-stable pkgs-old;
-            inherit system inputs vars;
-          };
-
-          modules = with specialArgs; [
-            ./hosts/${hostname}/configuration.nix
-            (import ./hosts/${hostname}/overlays)
-            sops-nix.nixosModules.sops # System-wide sops-nix
-
-            # Begin Home Manager Setup
-            home-manager.nixosModules.home-manager
-            rec {
-              home-manager = {
-                extraSpecialArgs = {
-                  inherit
-                    inputs
-                    vars
-                    doomemacs
-                    hostname
-                    pkgs-stable
-                    pkgs-old
-                    ;
-                };
-
-                useGlobalPkgs = true;
-                useUserPackages = true;
-                sharedModules = [
-                  inputs.sops-nix.homeManagerModules.sops # home-manager sops-nix
-                ];
-
-                users.${vars.username} = with specialArgs; {
-                  imports = [
-                    ./hosts/${hostname}/home.nix
-                  ];
-                };
-              };
-            } # End Home-Manager
-          ]; # End modules
-        }; # End gibson
-      }; # End nixosConfigurations
-
-      darwinConfigurations = with inputs; {
-        "macbook" = inputs.nix-darwin.lib.darwinSystem rec {
-          system = "aarch64-darwin";
-          specialArgs = {
-            hostname = "macbook";
-            inherit (pkgsFor "${system}") pkgs-darwin;
-            inherit inputs system vars;
-          };
-
-          modules = with specialArgs; [
-            ./hosts/${hostname}/darwin-configuration.nix
-
-            # Begin Home Manager Setup
-            home-manager.darwinModules.home-manager
-            {
-              home-manager = {
-                extraSpecialArgs = {
-                  inherit
-                    inputs
-                    vars
-                    doomemacs
-                    hostname
-                    pkgs-stable
-                    ;
-                };
-                useGlobalPkgs = true;
-                useUserPackages = true;
-                backupFileExtension = "before-nix";
-                sharedModules = [
-                  inputs.sops-nix.homeManagerModules.sops # home-manager sops-nix
-                ];
-
-                users.${vars.username} = with specialArgs; {
-                  imports = [
-                    ./hosts/${hostname}/home.nix
-                  ];
-                };
-              };
-            } # End Home-Manager
-          ]; # End modules
-        }; # End macbook
-      }; # End darwinConfigurations
-
-      homeManagerModules = {
-        default = import ./home/modules;
-        commonConfig = import ./home/user/common.nix;
-      };
-
-      nixosModules = import ./nixosModules;
+      imports = [
+        ./flakes/parts/hosts.nix
+        ./flakes/parts/modules.nix
+      ];
     };
 }

--- a/flakes/parts/hosts.nix
+++ b/flakes/parts/hosts.nix
@@ -1,0 +1,156 @@
+{ inputs, ... }:
+let
+  lib = inputs.nixpkgs.lib;
+  inherit (inputs)
+    nixpkgs
+    nixpkgs-stable
+    nixpkgs-old
+    nixpkgs-darwin
+    ;
+
+  username = "rickie";
+
+  vars = rec {
+    inherit username;
+    flakeSource = inputs.self;
+    secretsPath = builtins.toString inputs.nix-secrets;
+    syncthingPath = "/home/${username}/Sync";
+  };
+
+  hostPath = hostname: ./../../hosts/${hostname};
+
+  pkgsFor = system: {
+    pkgs-stable = import nixpkgs-stable {
+      inherit system;
+      config.allowUnfree = true;
+    };
+    pkgs-old = import nixpkgs-old {
+      inherit system;
+      config.allowUnfree = true;
+    };
+    pkgs-darwin = import nixpkgs-darwin {
+      inherit system;
+      config.allowUnfree = true;
+    };
+  };
+
+  mkHomeManagerModule =
+    {
+      platformModule,
+      hostname,
+      extraSpecialArgs ? { },
+      hmExtra ? { },
+    }:
+    [
+      platformModule
+      {
+        home-manager = {
+          extraSpecialArgs = {
+            inherit inputs vars hostname;
+            inherit (inputs) doomemacs;
+          }
+          // extraSpecialArgs;
+
+          useGlobalPkgs = true;
+          useUserPackages = true;
+
+          sharedModules = [
+            inputs.sops-nix.homeManagerModules.sops
+          ];
+
+          users.${vars.username} = {
+            imports = [
+              (hostPath hostname + /home.nix)
+            ];
+          };
+        }
+        // hmExtra;
+      }
+    ];
+
+  mkNixosHost =
+    { hostname, system, ... }:
+    let
+      p = pkgsFor system;
+    in
+    nixpkgs.lib.nixosSystem {
+      inherit system;
+
+      specialArgs = {
+        inherit
+          hostname
+          system
+          inputs
+          vars
+          ;
+        inherit (p) pkgs-stable pkgs-old;
+      };
+
+      modules = [
+        (hostPath hostname + /configuration.nix)
+        (import (hostPath hostname + /overlays))
+        inputs.sops-nix.nixosModules.sops
+      ]
+      ++ mkHomeManagerModule {
+        platformModule = inputs.home-manager.nixosModules.home-manager;
+        inherit hostname;
+        extraSpecialArgs = {
+          inherit (p) pkgs-stable pkgs-old;
+        };
+      };
+    };
+
+  mkDarwinHost =
+    { hostname, system, ... }:
+    let
+      p = pkgsFor system;
+    in
+    inputs.nix-darwin.lib.darwinSystem {
+      inherit system;
+
+      specialArgs = {
+        inherit
+          hostname
+          system
+          inputs
+          vars
+          ;
+        inherit (p) pkgs-darwin;
+      };
+
+      modules = [
+        (hostPath hostname + /darwin-configuration.nix)
+      ]
+      ++ mkHomeManagerModule {
+        platformModule = inputs.home-manager.darwinModules.home-manager;
+        inherit hostname;
+        hmExtra = {
+          backupFileExtension = "before-nix";
+        };
+      };
+    };
+
+  hosts = {
+    gibson = {
+      kind = "nixos";
+      hostname = "gibson";
+      system = "x86_64-linux";
+    };
+
+    macbook = {
+      kind = "darwin";
+      hostname = "macbook";
+      system = "aarch64-darwin";
+    };
+  };
+
+  filterHosts = kind: lib.filterAttrs (_: v: v.kind == kind) hosts;
+  mapHosts = f: hs: lib.mapAttrs (_: v: f v) hs;
+
+in
+{
+  flake = {
+    nixosConfigurations = mapHosts mkNixosHost (filterHosts "nixos");
+    darwinConfigurations = mapHosts mkDarwinHost (filterHosts "darwin");
+  };
+}

--- a/flakes/parts/modules.nix
+++ b/flakes/parts/modules.nix
@@ -1,0 +1,17 @@
+{ ... }:
+let
+  nix-modules = import ./../../nixosModules;
+in
+{
+  flake = {
+    homeManagerModules = {
+      default = import ./../../home/modules;
+      commonConfig = import ./../../home/user/common.nix;
+    };
+
+    nixosModules = nix-modules;
+    darwinModules = {
+      core = nix-modules.core;
+    };
+  };
+}

--- a/hosts/gibson/configuration.nix
+++ b/hosts/gibson/configuration.nix
@@ -10,17 +10,15 @@
   ...
 }:
 let
-  sddmTheme = inputs.hyprddm.packages.${pkgs.stdenv.hostPlatform.system}.default.override {
+  sddmTheme = inputs.sddm-themes.packages.${pkgs.stdenv.hostPlatform.system}.default.override {
     theme = "cyberpunk";
   };
 in
 {
   imports = [
-    # Include the results of the hardware scan.
     ./hardware-configuration.nix
-    inputs.self.nixosModules.core.nix
-    inputs.self.nixosModules.core.security
-    inputs.self.nixosModules.containers.pentesting
+    inputs.self.nixosModules.core
+    inputs.self.nixosModules.containers-pentesting
   ];
 
   networking = {
@@ -35,9 +33,6 @@ in
       externalInterface = "enp7s0";
     };
   };
-
-  # Set your time zone.
-  time.timeZone = "Europe/London";
 
   # Select internationalisation properties.
   i18n.defaultLocale = "en_GB.UTF-8";

--- a/hosts/macbook/darwin-configuration.nix
+++ b/hosts/macbook/darwin-configuration.nix
@@ -12,8 +12,7 @@
 {
 
   imports = [
-    inputs.self.nixosModules.core.nix
-    inputs.self.nixosModules.core.security
+    inputs.self.darwinModules.core
   ];
 
   networking.hostName = "macbook"; # Define your hostname.
@@ -25,24 +24,11 @@
     enable = false;
   };
 
-  # Enable CUPS to print documents.
-  # services.printing.enable = true;
-
-  # Enable sound.
-  # sound.enable = true;
-  # hardware.pulseaudio.enable = true;
-
-  # Enable touchpad support (enabled default in most desktopManager).
-  # services.xserver.libinput.enable = true;
-
-  # Define a user account. Don't forget to set a password with ‘passwd’.
   users.users.${vars.username} = {
     home = "/Users/${vars.username}";
     shell = pkgs.zsh;
   };
 
-  # List packages installed in system profile. To search, run:
-  # $ nix search wget
   environment.systemPackages = with pkgs; [
   ];
 
@@ -57,14 +43,6 @@
     variables = {
     };
   };
-
-  #security = {
-  #  pki = {
-  #    certificates = [
-  #      (builtins.readFile ../../certs/root-ca.crt)
-  #    ];
-  #  };
-  #};
 
   services.openssh.enable = false;
 

--- a/nixosModules/containers/default.nix
+++ b/nixosModules/containers/default.nix
@@ -1,7 +1,3 @@
 {
-  pentesting = {
-    imports = [
-      ./pentesting
-    ];
-  };
+  pentesting = import ./pentesting;
 }

--- a/nixosModules/core/default.nix
+++ b/nixosModules/core/default.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  imports = [
+    ./nix.nix
+    ./locale.nix
+    ./security.nix
+  ];
+}

--- a/nixosModules/core/locale.nix
+++ b/nixosModules/core/locale.nix
@@ -1,0 +1,12 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  # Set your time zone.
+  time.timeZone = "Europe/London";
+
+}

--- a/nixosModules/default.nix
+++ b/nixosModules/default.nix
@@ -1,9 +1,11 @@
 {
-  core = {
-    nix = import ./core/nix.nix;
-    locale = import ./core/locale.nix;
-    security = import ./core/security.nix;
-  };
+  core = import ./core;
+
+  core-nix = import ./core/nix.nix;
+  core-locale = import ./core/locale.nix;
+  core-security = import ./core/security.nix;
 
   containers = import ./containers;
+
+  containers-pentesting = import ./containers/pentesting;
 }


### PR DESCRIPTION
This is a **MAJOR** refactor of this repos central flake file 
It aims to split things into a more modular format using flake-parts.

The main changes are:

- Added flake-parts as a flake input, and tidied input naming (renamed hyprddm to sddm-themes).
- Reworked the flake structure to use flake-parts, making flake.nix a thin entrypoint.
- Reorganised host definitions and module exports into flakes/parts/{hosts,modules}.nix.
- Standardised module exports via nixosModules (and mirrored darwinModules exports where required)
  - This is to keep shared modules importable across both NixOS and nix-darwin.
- Expanded the existing flakes/ directory with a new parts/ subdirectory to hold flake-parts components.
- Updated individual host config where necessary
- Some nixosModules have required some minor refactors to ensure they work.. modularly
- Added in a locale.nix file to core nixosModules