### PR TITLE
host(gibson): wine removal + xorg lib update

### DIFF
--- a/hosts/gibson/configuration.nix
+++ b/hosts/gibson/configuration.nix
@@ -154,7 +154,6 @@ in
       sddmTheme
       v4l-utils
       vim
-      wineWowPackages.stagingFull
       xdg-utils
     ];
 

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -12,10 +12,10 @@
       steam = prev.steam.override {
         extraPkgs =
           pkgs: with pkgs; [
-            xorg.libXcursor
-            xorg.libXi
-            xorg.libXinerama
-            xorg.libXScrnSaver
+            libxcursor
+            libXi
+            libxinerama
+            libxscrnsaver
             libpng
             libpulseaudio
             libvorbis


### PR DESCRIPTION
- Removed the system-wide wine install as I usually favour ProtonGE
- Updated steam overlay to use updated xorg lib names as per upstream changes