### PR TITLE
github(ci): configure act + githook adjustments

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,3 +4,24 @@ set -eu
 # Format Nix files
 nix run nixpkgs#nixfmt-tree -- .
 nix run nixpkgs#statix -- check .
+set -eu
+
+# Get staged files, null separated, filter to .nix
+staged_nix_files="$(git diff --cached --name-only -z --diff-filter=ACMR | tr '\0' '\n' | grep -E '\.nix$' || true)"
+
+if [ -n "$staged_nix_files" ]; then
+  echo "Formatting staged Nix files"
+
+  # Run formatter only on staged .nix files
+  # shellcheck disable=SC2086
+  nix run nixpkgs#nixfmt -- $staged_nix_files
+
+  # Re stage in case formatting changed files
+  # shellcheck disable=SC2086
+  git add -- $staged_nix_files
+else
+  echo "No staged Nix files to format"
+fi
+
+echo "Statix"
+nix run nixpkgs#statix -- check .

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DOCKER_HOST="unix://$XDG_RUNTIME_DIR/podman/podman.sock"
+
+echo "Running gitleaks (native) …"
+nix run nixpkgs#gitleaks -- protect --staged --redact
+
+echo "Running CI jobs via act …"
+act push -j eval-check --pull=false --rm
+
+echo "All local checks passed, proceeding with push"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,4 +174,4 @@ jobs:
       - name: Flake check
         run: |
           set -euo pipefail
-          nix flake check --no-write-lock-file
+          nix flake check --no-write-lock-file --all-systems

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.ci-secrets
 secrets/
 lost+found

--- a/home/user/gibson.nix
+++ b/home/user/gibson.nix
@@ -25,6 +25,7 @@
     };
 
     packages = with pkgs; [
+      act
       bat
       bitwarden-desktop
       bottles

--- a/hosts/gibson/configuration.nix
+++ b/hosts/gibson/configuration.nix
@@ -18,7 +18,7 @@ in
   imports = [
     ./hardware-configuration.nix
     inputs.self.nixosModules.core
-    inputs.self.nixosModules.containers-pentesting
+    inputs.self.nixosModules.containers
   ];
 
   networking = {
@@ -158,17 +158,18 @@ in
     ];
 
     sessionVariables = rec {
+      ADW_DISABLE_PORTAL = "1";
       CLIPBOARD_NOGUI = "1";
+      DOCKER_HOST = "unix://$XDG_RUNTIME_DIR/podman/podman.sock";
       ENABLE_DPMS = "1";
       ENABLE_DDC = "1";
-      ADW_DISABLE_PORTAL = "1";
       GTK_THEME = "Dracula:dark";
       GSETTINGS_BACKEND = "keyfile";
       GBM_BACKEND = "nvidia-drm";
       NVD_BACKEND = "direct";
       LIBVA_DRIVER_NAME = "nvidia";
-      __GLX_VENDOR_LIBRARY_NAME = "nvidia";
       WLR_NO_HARDWARE_CURSORS = "1";
+      __GLX_VENDOR_LIBRARY_NAME = "nvidia";
       __GL_MaxFramesAllowed = "1";
       __GL_GSYNC_ALLOWED = "1";
       __GL_VRR_ALLOWED = "0";
@@ -516,9 +517,6 @@ in
   };
 
   virtualisation = {
-    libvirtd = {
-      enable = true;
-    };
   };
 
   sops = {

--- a/nixosModules/containers/default.nix
+++ b/nixosModules/containers/default.nix
@@ -1,3 +1,6 @@
 {
-  pentesting = import ./pentesting;
+  imports = [
+    ./pentesting
+    ./virtualisation
+  ];
 }

--- a/nixosModules/containers/virtualisation/default.nix
+++ b/nixosModules/containers/virtualisation/default.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  pkgs,
+  vars,
+  ...
+}:
+
+{
+  virtualisation = {
+    podman = {
+      enable = true;
+      dockerCompat = true;
+      dockerSocket.enable = false;
+    };
+
+    libvirtd = {
+      enable = true;
+    };
+  };
+
+  users.users.${vars.username} = {
+    subUidRanges = [
+      {
+        startUid = 100000;
+        count = 65536;
+      }
+    ];
+    subGidRanges = [
+      {
+        startGid = 100000;
+        count = 65536;
+      }
+    ];
+  };
+}

--- a/nixosModules/default.nix
+++ b/nixosModules/default.nix
@@ -8,4 +8,5 @@
   containers = import ./containers;
 
   containers-pentesting = import ./containers/pentesting;
+  containers-virtualisation = import ./containers/virtualisation;
 }


### PR DESCRIPTION
N.B - A further commit will likely:

- rm jobs in git-ci if they are handled locally to cut down on PR merge times
- Review the existing CI jobs to see if github runners can handle full build tests
- Add `act` local secrets into sops-nix and have home-manager supply that file

***

- Adds the "act" package into hosts/gibson home-manager
- Adds a pre-push githook to
  - Run local secrets check with gitleaks
  - Run the eval check CI job locally
- Modifies the pre-commit githook to:
  - Format staged .nix files only
  - Add any formatted files as staged files
  - Handle a local statix check
- Updated gitignore to ignore the local secrets file for act
- Adds a new virtualisation module to enable podman
- Podman is used by act to run github actions locally
- Declared a system-wide DOCKER_HOST env var for act to use
- Moved libvirtd config into the container/virtulisation module