### PR TITLE
host(gibson): add jellyfin, media tag + rm overlay

### DIFF
--- a/home/user/gibson.nix
+++ b/home/user/gibson.nix
@@ -40,6 +40,7 @@
         useGameMode = true;
       })
       (import ../modules/applications/dim-screen { inherit pkgs; })
+      jellyfin-desktop
       jellyfin-mpv-shim
       jq
       keyutils

--- a/hosts/gibson/applications/hypr/hyprland.conf
+++ b/hosts/gibson/applications/hypr/hyprland.conf
@@ -164,8 +164,12 @@
         windowrule = match:class discord,tag +social
         windowrule = match:class signal,tag +social
 
+        windowrule = match:class org.jellyfin.JellyfinDesktop,tag +media
+        windowrule = match:class Cider,tag +media
+
         # Groups
-        windowrule = match:tag social, group set lock invade
+        windowrule = match:tag social, group set always lock invade
+        windowrule = match:tag media, group set always lock invade
 
         # Startup
         exec-once = systemctl --user start hyprpolkitagent
@@ -173,9 +177,10 @@
         exec-once = jellyfin-mpv-shim
 
         exec-once = mpvpaper '*' /home/rickie/.config/Wallpapers/Cyberpunk/Cyberpunk-2077-Game-4K-Animated-Desktop.mp4 --mpv-options="profile=wallpaper" -f
+        exec-once = discord
         exec-once = kitty -1
-        exec-once = signal-desktop
+        exec-once = jellyfin-desktop
         exec-once = qutebrowser
         exec-once = cider-2
-        exec-once = discord
         exec-once = bitwarden
+        exec-once = signal-desktop

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -34,43 +34,6 @@
       mpv = prev.mpv.override {
         inherit (final) mpv-unwrapped;
       };
-      # via PR #487740
-      waybar =
-        let
-          libcavaVersion = "0.10.7-beta";
-          libcavaSrc = prev.fetchFromGitHub {
-            owner = "LukashonakV";
-            repo = "cava";
-            tag = "v${libcavaVersion}";
-            hash = "sha256-IX1B375gTwVDRjpRfwKGuzTAZOV2pgDWzUd4bW2cTDU=";
-          };
-          stageLibcava = ''
-            pushd "$sourceRoot"
-            cp -R --no-preserve=mode,ownership ${libcavaSrc} subprojects/cava-${libcavaVersion}
-            patchShebangs .
-            popd
-          '';
-        in
-        prev.waybar.overrideAttrs (old: rec {
-          version = "0.15.0";
-
-          src = prev.fetchFromGitHub {
-            owner = "Alexays";
-            repo = "Waybar";
-            tag = version;
-            hash = "sha256-49ZKgK96a9uFip+svOdnw397xcEjiftXzd9gyv1H3sU=";
-          };
-
-          postUnpack =
-            let
-              oldPost =
-                if old ? postUnpack then
-                  (if builtins.isList old.postUnpack then old.postUnpack else [ old.postUnpack ])
-                else
-                  [ ];
-            in
-            oldPost ++ [ stageLibcava ];
-        });
     })
   ];
 }


### PR DESCRIPTION
- Adds in the native jellyfin-desktop appliance via home-manager
- Removes the waybar 0.15.0 override as thats now pkg'd upstream
- Adds in a hyprland tag for media based applications
- I've also re-ordered the config slightly