### PR TITLE
github(ci): another minor refactor

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,24 +1,12 @@
-#!/usr/bin/env sh
-set -eu
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Format Nix files
-nix run nixpkgs#nixfmt-tree -- .
-nix run nixpkgs#statix -- check .
-set -eu
+mapfile -d '' staged < <(git diff --cached --name-only -z --diff-filter=ACMR | tr '\0' '\n' | grep -E '\.nix$' || true)
 
-# Get staged files, null separated, filter to .nix
-staged_nix_files="$(git diff --cached --name-only -z --diff-filter=ACMR | tr '\0' '\n' | grep -E '\.nix$' || true)"
-
-if [ -n "$staged_nix_files" ]; then
+if (( ${#staged[@]} > 0 )); then
   echo "Formatting staged Nix files"
-
-  # Run formatter only on staged .nix files
-  # shellcheck disable=SC2086
-  nix run nixpkgs#nixfmt -- $staged_nix_files
-
-  # Re stage in case formatting changed files
-  # shellcheck disable=SC2086
-  git add -- $staged_nix_files
+  nix run nixpkgs#nixfmt -- "${staged[@]}"
+  git add -- "${staged[@]}"
 else
   echo "No staged Nix files to format"
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,12 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export DOCKER_HOST="unix://$XDG_RUNTIME_DIR/podman/podman.sock"
-
 echo "Running gitleaks (native) …"
 nix run nixpkgs#gitleaks -- protect --staged --redact
 
-echo "Running CI jobs via act …"
-act push -j eval-check --pull=false --rm
+echo "Running flake shape check …"
+nix flake show --no-write-lock-file >/dev/null
+
+# Detect platform
+os="$(uname -s)"
+
+case "$os" in
+  Linux)
+    echo "Running eval check for nixosConfigurations.gibson (linux) …"
+    nix eval .#nixosConfigurations.gibson.pkgs.stdenv.hostPlatform.system \
+      --no-write-lock-file >/dev/null
+    ;;
+  Darwin)
+    echo "Running eval check for darwinConfigurations.macbook (darwin) …"
+    nix eval .#darwinConfigurations.macbook.pkgs.stdenv.hostPlatform.system \
+      --no-write-lock-file >/dev/null
+    ;;
+  *)
+    echo "Unknown OS '$os', skipping platform specific eval checks"
+    ;;
+esac
 
 echo "All local checks passed, proceeding with push"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,15 @@ jobs:
       - uses: DeterminateSystems/determinate-nix-action@v3
       - uses: DeterminateSystems/flakehub-cache-action@v3
 
-      - name: Nix format check (nixfmt-tree)
+      - name: Nix format check (nixfmt)
         run: |
           set -euo pipefail
-          nix run nixpkgs#nixfmt-tree -- .
+          nix run nixpkgs#nixfmt -- .
           git diff --exit-code || {
             echo ""
             echo "Formatting required."
-            echo "Run this locally to fix:"
-            echo "  nix run nixpkgs#nixfmt-tree -- ."
+            echo "Run this locally to fix (or just commit again and let hooks handle it):"
+            echo "  nix run nixpkgs#nixfmt -- ."
             echo ""
             exit 1
           }
@@ -80,16 +80,18 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: DeterminateSystems/flakehub-cache-action@v3
+
+      - name: Run gitleaks (native)
+        run: |
+          set -euo pipefail
+          nix run nixpkgs#gitleaks -- detect --source . --redact
 
   eval-check:
     name: eval check (linux)
@@ -108,7 +110,7 @@ jobs:
         run: |
           set -euo pipefail
           nix flake show --no-write-lock-file
-          nix eval .#nixosConfigurations.gibson.pkgs.stdenv.hostPlatform.system --no-write-lock-file
+          nix eval .#nixosConfigurations.gibson.pkgs.stdenv.hostPlatform.system --no-write-lock-file >/dev/null
 
   darwin-eval-check:
     name: eval check (darwin)
@@ -127,7 +129,7 @@ jobs:
         run: |
           set -euo pipefail
           nix flake show --no-write-lock-file
-          nix eval .#darwinConfigurations.macbook.pkgs.stdenv.hostPlatform.system --no-write-lock-file
+          nix eval .#darwinConfigurations.macbook.pkgs.stdenv.hostPlatform.system --no-write-lock-file >/dev/null
 
   flake-secrets-check:
     name: full flake check (with secrets)


### PR DESCRIPTION
- Enforced use of bash on pre-commit/push hook scripts
- Minor formatter logic refactor to better acquire staged files list
- Moved to native nix checks for local pre-push jobs
- Added in logic to run specific local checks based on system type
- Updated Github CI to use nixfmt rather than nixfmt-tree
- Github CI also now uses native nix gitleaks scanning
- Adjusts the eval check jobs to send output > /dev/null
- Other very minor adjustments