### PR TITLE
host(macbook): make doomemacs worky

### DIFF
--- a/home/user/common.nix
+++ b/home/user/common.nix
@@ -43,6 +43,11 @@ in
         GNUMAKEFLAGS = "-j12";
         LESSHISTFILE = "-";
       };
+      initContent = ''
+        vim() {
+          emacsclient -c --tty "$@"
+        }
+      '';
       oh-my-zsh = {
         enable = true;
         theme = "gentoo";

--- a/home/user/gibson.nix
+++ b/home/user/gibson.nix
@@ -115,10 +115,6 @@
         path = "${config.xdg.dataHome}/zsh/zsh_history";
       };
       initContent = ''
-        vim() {
-          emacsclient -c --tty "$@"
-        }
-
         bindkey -M viins '\e.' insert-last-word
       '';
     };

--- a/hosts/macbook/darwin-configuration.nix
+++ b/hosts/macbook/darwin-configuration.nix
@@ -46,5 +46,21 @@
 
   services.openssh.enable = false;
 
-  system.stateVersion = 5;
+  launchd.user.agents.emacs-daemon = {
+    serviceConfig = {
+      ProgramArguments = [
+        "${pkgs.emacs}/bin/emacs"
+        "--fg-daemon"
+      ];
+      RunAtLoad = true;
+      KeepAlive = true;
+      StandardOutPath = "/tmp/emacs-daemon.log";
+      StandardErrorPath = "/tmp/emacs-daemon.err";
+    };
+  };
+
+  system = {
+    stateVersion = 5;
+    primaryUser = "${vars.username}";
+  };
 }


### PR DESCRIPTION
- Adds some darwin logic to the doomemacs application module
- Moves the vim -> emacsclient zsh function to hm common module
- Adds in a launchd agent for emacs on darwin so it can run in the bg
- Sets a darwin specific primaryUser option to allow emacs daemon launcher
- Added logic for the doomemacs activation permissions fix