### PR TITLE
host(macbook): more doomemacs changes

### DIFF
--- a/home/modules/applications/doomemacs/doom/config.el
+++ b/home/modules/applications/doomemacs/doom/config.el
@@ -126,3 +126,7 @@
 (set-language-environment "UTF-8")
 (set-default-coding-systems 'utf-8)
 (prefer-coding-system 'utf-8)
+
+(setq mac-option-modifier 'meta
+      mac-command-modifier 'super
+      mac-right-option-modifier 'none)

--- a/home/user/common.nix
+++ b/home/user/common.nix
@@ -45,7 +45,7 @@ in
       };
       initContent = ''
         vim() {
-          emacsclient -c --tty "$@"
+          emacsclient -t "$@"
         }
       '';
       oh-my-zsh = {

--- a/hosts/gibson/configuration.nix
+++ b/hosts/gibson/configuration.nix
@@ -176,7 +176,7 @@ in
     };
 
     variables = rec {
-      EDITOR = "emacsclient --create-frame --tty";
+      EDITOR = "emacsclient -t";
     };
 
     pathsToLink = [

--- a/hosts/macbook/darwin-configuration.nix
+++ b/hosts/macbook/darwin-configuration.nix
@@ -29,10 +29,8 @@
     shell = pkgs.zsh;
   };
 
-  environment.systemPackages = with pkgs; [
-  ];
-
   environment = {
+    systemPackages = with pkgs; [ ];
     etc = {
       "nix/nix.custom.conf" = {
         text = ''
@@ -40,7 +38,8 @@
         '';
       };
     };
-    variables = {
+    variables = rec {
+      EDITOR = "emacsclient -t";
     };
   };
 
@@ -52,6 +51,13 @@
         "${pkgs.emacs}/bin/emacs"
         "--fg-daemon"
       ];
+      EnvironmentVariables = {
+        TERMINFO_DIRS =
+          "/Applications/Ghostty.app/Contents/Resources/terminfo:"
+          + "${pkgs.ncurses.out}/share/terminfo:"
+          + "/usr/share/terminfo:/etc/terminfo";
+      };
+
       RunAtLoad = true;
       KeepAlive = true;
       StandardOutPath = "/tmp/emacs-daemon.log";


### PR DESCRIPTION
- Sets some mac-specific modifiers in dooms config
- Updated all commands calling emacsclient
- Added in some env vars to Macbooks emacs launchd agent
  - To allow terminfo to be sourced properly when emacs is used in ghostty
  - This fixes poor background colour rendering for doom emacs themes