### PR TITLE
host(macbook): set qutebrowser default font size

### DIFF
--- a/home/user/macbook.nix
+++ b/home/user/macbook.nix
@@ -36,6 +36,10 @@
         user.signingKey = "D4D5DFADF6AE96D9";
       };
     };
+
+    qutebrowser.extraConfig = ''
+      c.fonts.default_size = "12pt"
+    '';
   };
 
   ## END PROGAMS


### PR DESCRIPTION
- My main rig uses a font size too small for my Macbook
- Bumped this to a slightly larger size