### PR TITLE
overlay(macbook): adds overlay for darwin systems

### DIFF
--- a/flakes/parts/hosts.nix
+++ b/flakes/parts/hosts.nix
@@ -120,6 +120,7 @@ let
 
       modules = [
         (hostPath hostname + /darwin-configuration.nix)
+        (import (hostPath hostname + /overlays))
       ]
       ++ mkHomeManagerModule {
         platformModule = inputs.home-manager.darwinModules.home-manager;

--- a/hosts/macbook/overlays/default.nix
+++ b/hosts/macbook/overlays/default.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  pkgs,
+  lib,
+  vars,
+  inputs,
+  ...
+}:
+{
+  nixpkgs.overlays = [
+    (_final: prev: {
+      # Can be rm'd when this merges into nixos-unstable: https://github.com/NixOS/nixpkgs/pull/493943
+      yt-dlp = prev.yt-dlp.overridePythonAttrs (override: {
+        dependencies = __filter (
+          dep:
+          !(__elem dep.pname [
+            "cffi"
+            "secretstorage"
+          ])
+        ) override.dependencies;
+      });
+    })
+  ];
+}


### PR DESCRIPTION
- Follows the same path convention as Linux hosts
- Adds in a overlay for yt-dlp on `hosts/macbook`
  - This will be resolved with the flake update this coming Sunday