### PR TITLE
container(pentesting): fix wordlist pkg build

### DIFF
--- a/nixosModules/containers/pentesting/default.nix
+++ b/nixosModules/containers/pentesting/default.nix
@@ -8,6 +8,28 @@
 
 let
   hostUser = "5ysk3y";
+
+  # Can be rm'd once https://github.com/NixOS/nixpkgs/pull/495753 is merged upstream
+  wfuzzOverlay = final: prev: {
+    python313Packages = prev.python313Packages.overrideScope (
+      _pyFinal: pyPrev: {
+        wfuzz = pyPrev.wfuzz.overridePythonAttrs (old: {
+          postPatch =
+            prev.lib.replaceStrings
+              [
+                ''
+                  substituteInPlace setup.py \
+                    --replace-fail "pyparsing>=2.4*" "pyparsing>=2.4"
+                ''
+              ]
+              [ "" ]
+              (old.postPatch or "");
+        });
+      }
+    );
+
+    inherit (final.python313Packages) wfuzz;
+  };
 in
 {
   containers.pentesting = {
@@ -51,6 +73,7 @@ in
         };
 
         nixpkgs.config.allowUnfree = true;
+        nixpkgs.overlays = [ wfuzzOverlay ];
 
         networking = {
           useHostResolvConf = false;


### PR DESCRIPTION
- Due to an upstream issue with python3's wfuzz dependency
- Can be removed when the commented PR has been merged