### PR TITLE
overlay(gibson): move less from common -> gibson

### DIFF
--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -57,6 +57,17 @@
             }
         '';
       });
+
+      # Temporary workaround for less 691 xterm-kitty pager regression.
+      # Remove once nixpkgs includes less >= 692 everywhere we build.
+      # https://github.com/NixOS/nixpkgs/pull/490763
+      less = prev.less.overrideAttrs (_: rec {
+        version = "692";
+        src = prev.fetchurl {
+          url = "https://www.greenwoodsoftware.com/less/less-${version}.tar.gz";
+          hash = "sha256-YTAPYDeY7PHXeGVweJ8P8/WhrPB1pvufdWg30WbjfRQ=";
+        };
+      });
     })
   ];
 }

--- a/nixosModules/core/overlays.nix
+++ b/nixosModules/core/overlays.nix
@@ -3,15 +3,6 @@ _:
 {
   nixpkgs.overlays = [
     (final: prev: {
-      # Temporary workaround for less 691 xterm-kitty pager regression.
-      # Remove once nixpkgs includes less >= 692 everywhere we build.
-      less = prev.less.overrideAttrs (_: rec {
-        version = "692";
-        src = prev.fetchurl {
-          url = "https://www.greenwoodsoftware.com/less/less-${version}.tar.gz";
-          hash = "sha256-YTAPYDeY7PHXeGVweJ8P8/WhrPB1pvufdWg30WbjfRQ=";
-        };
-      });
     })
   ];
 }


### PR DESCRIPTION
- I added this as a common overlay for all machines initially
- This has now been moved to host-specific config
- Rebuilds on darwin are enormous if its included
- Darwin itself actually doesnt exhibit the bug im fixing