### PR TITLE
github(ci): fix the dependabot PR pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
 
   flake-secrets-check:
     name: full flake check (with secrets)
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:


### PR DESCRIPTION
- Adds a condition to the full flake check to skip for dependabot PRs
- This job currently fails due to dependabots inability to view github secrets.