### PR TITLE
flake: add import-tree to inputs and use it

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -250,6 +250,21 @@
         "type": "github"
       }
     },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1773693634,
+        "narHash": "sha256-BtZ2dtkBdSUnFPPFc+n0kcMbgaTxzFNPv2iaO326Ffg=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "c41e7d58045f9057880b0d85e1152d6a4430dbf1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
     "mac-app-util": {
       "inputs": {
         "cl-nix-lite": "cl-nix-lite",
@@ -641,6 +656,7 @@
         "emacs-overlay": "emacs-overlay",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",
+        "import-tree": "import-tree",
         "mac-app-util": "mac-app-util",
         "nix-darwin": "nix-darwin",
         "nix-gaming": "nix-gaming",

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
 
     # other stuff
     flake-parts.url = "github:hercules-ci/flake-parts";
+    import-tree.url = "github:vic/import-tree";
 
     nixos-xivlauncher-rb.url = "github:drakon64/nixos-xivlauncher-rb";
     nixos-xivlauncher-rb.inputs.nixpkgs.follows = "nixpkgs";
@@ -42,15 +43,13 @@
 
   outputs =
     inputs@{ flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [
-        "x86_64-linux"
-        "aarch64-darwin"
-      ];
-
-      imports = [
-        ./flake/parts/hosts.nix
-        ./flake/parts/modules.nix
-      ];
-    };
+    flake-parts.lib.mkFlake { inherit inputs; } (
+      {
+        systems = [
+          "x86_64-linux"
+          "aarch64-darwin"
+        ];
+      }
+      // (inputs.import-tree ./flake/parts)
+    );
 }


### PR DESCRIPTION
- As suggested this adds github:vic/import-tree to flake inputs
- flake outputs then use that module to import all flake part files instead

This is the initial step in an ongoing, larger refeactor to migrate the repo over to a dendritic pattern style of code.