### PR TITLE
host(gibson): add zswap + rm libvirt overlay

### DIFF
--- a/hosts/gibson/applications/hypr/hyprland.conf
+++ b/hosts/gibson/applications/hypr/hyprland.conf
@@ -162,7 +162,7 @@
         windowrule = match:class ^(burp-StartBurp|firefox)$,tag +h4x0r
 
         # Groups
-        windowrule = group set always lock invade, match:class ^(discord|signal|Webcord)$
+        windowrule = group set always lock invade, match:class ^(discord|signal|Webcord)$, float off
         windowrule = group set always lock invade, match:class ^(burp-StartBurp|firefox)$
         windowrule = group set always lock invade, match:class ^(Cider|org.jellyfin.JellyfinDesktop)$
 

--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -34,6 +34,10 @@
       "video=DP-1:2560x1440@144"
       "video=DP-2:1920x1080@144"
       "video=HDMI-A-1:1920x1080@60"
+      "zswap.enabled=1"
+      "zswap.compressor=lz4"
+      "zswap.max_pool_percent=20"
+      "zswap.shrinker_enabled=1"
     ];
     extraModulePackages = with config.boot.kernelPackages; [ ];
     loader = {

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -35,29 +35,6 @@
         inherit (final) mpv-unwrapped;
       };
 
-      ## Can be rm'd once https://github.com/NixOS/nixpkgs/pull/496839 is merged upstream
-      libvirt = prev.libvirt.overrideAttrs (old: {
-        nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.makeWrapper ];
-
-        buildInputs = (old.buildInputs or [ ]) ++ [ prev.systemd ];
-
-        postPatch = (old.postPatch or "") + ''
-          substituteInPlace src/secret/virt-secret-init-encryption.service.in \
-            --replace-fail /usr/bin/sh ${
-              prev.lib.getExe (
-                prev.writeShellApplication {
-                  name = "virt-secret-init-encryption-sh";
-                  runtimeInputs = [
-                    prev.coreutils
-                    prev.systemd
-                  ];
-                  text = ''exec ${prev.runtimeShell} "$@"'';
-                }
-              )
-            }
-        '';
-      });
-
       # Temporary workaround for less 691 xterm-kitty pager regression.
       # Remove once nixpkgs includes less >= 692 everywhere we build.
       # https://github.com/NixOS/nixpkgs/pull/490763


### PR DESCRIPTION
- Adds zswap config into gibsons system kernel params
- Removes the libvirt overlay now upstream has been fixed
- Makes a cheeky adjustment to the hyprland window rule for social apps