### PR TITLE
flake: add in profiles + split host declarations

### DIFF
--- a/flake/hosts/default.nix
+++ b/flake/hosts/default.nix
@@ -1,0 +1,22 @@
+{
+  inputs,
+  mkVars,
+  username,
+}:
+{
+  gibson = import ./gibson.nix {
+    inherit
+      inputs
+      mkVars
+      username
+      ;
+  };
+
+  macbook = import ./macbook.nix {
+    inherit
+      inputs
+      mkVars
+      username
+      ;
+  };
+}

--- a/flake/hosts/gibson.nix
+++ b/flake/hosts/gibson.nix
@@ -1,0 +1,41 @@
+{
+  inputs,
+  mkVars,
+  username,
+}:
+let
+  hostname = "gibson";
+  system = "x86_64-linux";
+  path = ./../../hosts/gibson;
+in
+rec {
+  kind = "nixos";
+  inherit hostname system path;
+
+  systemModule = path + /configuration.nix;
+  homeModule = path + /home.nix;
+  overlaysModule = path + /overlays;
+
+  systemProfiles = [
+    ./../../profiles/nixos/base.nix
+  ];
+
+  homeProfiles = [
+    ./../../profiles/home/common.nix
+    ./../../profiles/home/gibson.nix
+  ];
+
+  modules = [
+    systemModule
+    overlaysModule
+  ];
+
+  vars = mkVars {
+    inherit
+      inputs
+      username
+      hostname
+      system
+      ;
+  };
+}

--- a/flake/hosts/macbook.nix
+++ b/flake/hosts/macbook.nix
@@ -1,0 +1,41 @@
+{
+  inputs,
+  mkVars,
+  username,
+}:
+let
+  hostname = "macbook";
+  system = "aarch64-darwin";
+  path = ./../../hosts/macbook;
+in
+rec {
+  kind = "darwin";
+  inherit hostname system path;
+
+  systemModule = path + /darwin-configuration.nix;
+  homeModule = path + /home.nix;
+  overlaysModule = path + /overlays;
+
+  systemProfiles = [
+    ./../../profiles/darwin/base.nix
+  ];
+
+  homeProfiles = [
+    ./../../profiles/home/common.nix
+    ./../../profiles/home/macbook.nix
+  ];
+
+  modules = [
+    systemModule
+    overlaysModule
+  ];
+
+  vars = mkVars {
+    inherit
+      inputs
+      username
+      hostname
+      system
+      ;
+  };
+}

--- a/flake/parts/hosts/registry.nix
+++ b/flake/parts/hosts/registry.nix
@@ -51,6 +51,16 @@ in
               readOnly = true;
             };
 
+            systemProfiles = lib.mkOption {
+              type = lib.types.listOf lib.types.path;
+              readOnly = true;
+            };
+
+            homeProfiles = lib.mkOption {
+              type = lib.types.listOf lib.types.path;
+              readOnly = true;
+            };
+
             vars = lib.mkOption {
               type = lib.types.lazyAttrsOf lib.types.anything;
               readOnly = true;
@@ -109,7 +119,7 @@ in
               ];
 
               users.${host.vars.username} = {
-                imports = [
+                imports = host.homeProfiles ++ [
                   host.homeModule
                 ];
               };
@@ -119,62 +129,12 @@ in
         ];
     };
 
-    repo.hosts = {
-      gibson =
-        let
-          hostname = "gibson";
-          system = "x86_64-linux";
-          path = ./../../../hosts/gibson;
-        in
-        rec {
-          kind = "nixos";
-          inherit hostname system path;
-          systemModule = path + /configuration.nix;
-          homeModule = path + /home.nix;
-          overlaysModule = path + /overlays;
-
-          modules = [
-            systemModule
-            overlaysModule
-          ];
-
-          vars = mkVars {
-            inherit
-              inputs
-              username
-              hostname
-              system
-              ;
-          };
-        };
-
-      macbook =
-        let
-          hostname = "macbook";
-          system = "aarch64-darwin";
-          path = ./../../../hosts/macbook;
-        in
-        rec {
-          kind = "darwin";
-          inherit hostname system path;
-          systemModule = path + /darwin-configuration.nix;
-          homeModule = path + /home.nix;
-          overlaysModule = path + /overlays;
-
-          modules = [
-            systemModule
-            overlaysModule
-          ];
-
-          vars = mkVars {
-            inherit
-              inputs
-              username
-              hostname
-              system
-              ;
-          };
-        };
+    repo.hosts = import ../../hosts {
+      inherit
+        inputs
+        mkVars
+        username
+        ;
     };
   };
 }

--- a/flake/parts/platforms/darwin.nix
+++ b/flake/parts/platforms/darwin.nix
@@ -22,7 +22,8 @@ let
       };
 
       modules =
-        host.modules
+        host.systemProfiles
+        ++ host.modules
         ++ repoLib.mkHomeManagerModule {
           platformModule = inputs.home-manager.darwinModules.home-manager;
           inherit host;

--- a/flake/parts/platforms/nixos.nix
+++ b/flake/parts/platforms/nixos.nix
@@ -22,7 +22,8 @@ let
       };
 
       modules =
-        host.modules
+        host.systemProfiles
+        ++ host.modules
         ++ [
           inputs.sops-nix.nixosModules.sops
         ]

--- a/hosts/gibson/configuration.nix
+++ b/hosts/gibson/configuration.nix
@@ -17,8 +17,6 @@ in
 {
   imports = [
     ./hardware-configuration.nix
-    inputs.self.nixosModules.core
-    inputs.self.nixosModules.containers
   ];
 
   networking = {

--- a/hosts/gibson/home.nix
+++ b/hosts/gibson/home.nix
@@ -6,9 +6,6 @@
 }:
 {
   imports = [
-    ../../home/user/gibson.nix
-    inputs.wayland-pipewire-idle-inhibit.homeModules.default
-    inputs.self.homeManagerModules.default
-    inputs.self.homeManagerModules.commonConfig
+    ./../../home/user/gibson.nix
   ];
 }

--- a/hosts/macbook/darwin-configuration.nix
+++ b/hosts/macbook/darwin-configuration.nix
@@ -11,10 +11,6 @@
 }:
 {
 
-  imports = [
-    inputs.self.darwinModules.core
-  ];
-
   networking.hostName = "macbook"; # Define your hostname.
 
   # Set your time zone.

--- a/hosts/macbook/home.nix
+++ b/hosts/macbook/home.nix
@@ -6,9 +6,6 @@
 }:
 {
   imports = [
-    ../../home/user/macbook.nix
-    inputs.self.homeManagerModules.default
-    inputs.self.homeManagerModules.commonConfig
-    inputs.mac-app-util.homeManagerModules.default
+    ./../../home/user/macbook.nix
   ];
 }

--- a/profiles/darwin/base.nix
+++ b/profiles/darwin/base.nix
@@ -1,0 +1,9 @@
+{
+  inputs,
+  ...
+}:
+{
+  imports = [
+    inputs.self.darwinModules.core
+  ];
+}

--- a/profiles/home/common.nix
+++ b/profiles/home/common.nix
@@ -1,0 +1,10 @@
+{
+  inputs,
+  ...
+}:
+{
+  imports = [
+    inputs.self.homeManagerModules.default
+    inputs.self.homeManagerModules.commonConfig
+  ];
+}

--- a/profiles/home/gibson.nix
+++ b/profiles/home/gibson.nix
@@ -1,0 +1,6 @@
+{ inputs, ... }:
+{
+  imports = [
+    inputs.wayland-pipewire-idle-inhibit.homeModules.default
+  ];
+}

--- a/profiles/home/macbook.nix
+++ b/profiles/home/macbook.nix
@@ -1,0 +1,6 @@
+{ inputs, ... }:
+{
+  imports = [
+    inputs.mac-app-util.homeManagerModules.default
+  ];
+}

--- a/profiles/nixos/base.nix
+++ b/profiles/nixos/base.nix
@@ -1,0 +1,10 @@
+{
+  inputs,
+  ...
+}:
+{
+  imports = [
+    inputs.self.nixosModules.core
+    inputs.self.nixosModules.containers
+  ];
+}


### PR DESCRIPTION
Next steps in my attempts to migrate to dendritic nix:

- add adapter-style system and home profiles
- switch host entry points to consume profiles
- move profile selection into host metadata
- make platform assemblers compose systemProfiles and homeProfiles
- thin host files down to local overrides
- split concrete host declarations into flake/hosts/*
- keep registry.nix focused on schema, helpers, and aggregation

Again, no intended behavioural changes.