### PR TITLE
host(gibson): enable ntsync

### DIFF
--- a/home/user/gibson.nix
+++ b/home/user/gibson.nix
@@ -213,6 +213,9 @@
 
     mangohud = {
       enable = true;
+      settings = {
+        winesync = 1;
+      };
     };
 
     yt-dlp = {

--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -22,6 +22,7 @@
       "nvidia_modeset"
       "nvidia_uvm"
       "nvidia_drm"
+      "ntsync"
     ];
     blacklistedKernelModules = [
       "ath12k_pci"


### PR DESCRIPTION
- Adds in the ntsync kernel module
- Updates mangohud config to show the sync method used in games