### PR TITLE
host(gibson): fix upstream warnings + rm overlay

### DIFF
--- a/home/user/gibson.nix
+++ b/home/user/gibson.nix
@@ -123,6 +123,7 @@
       settings = {
         user.signingKey = "7D73BA8CF10F7F67";
       };
+      signing.format = "openpgp";
     };
 
     imv = {
@@ -369,6 +370,9 @@
       extraConfig = {
         gtk-application-prefer-dark-theme = 1;
       };
+    };
+    gtk4 = {
+      inherit (config.gtk) theme;
     };
   };
 

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -34,17 +34,6 @@
       mpv = prev.mpv.override {
         inherit (final) mpv-unwrapped;
       };
-
-      # Temporary workaround for less 691 xterm-kitty pager regression.
-      # Remove once nixpkgs includes less >= 692 everywhere we build.
-      # https://github.com/NixOS/nixpkgs/pull/490763
-      less = prev.less.overrideAttrs (_: rec {
-        version = "692";
-        src = prev.fetchurl {
-          url = "https://www.greenwoodsoftware.com/less/less-${version}.tar.gz";
-          hash = "sha256-YTAPYDeY7PHXeGVweJ8P8/WhrPB1pvufdWg30WbjfRQ=";
-        };
-      });
     })
   ];
 }


### PR DESCRIPTION
- Removes the less 692 overlay as thats now been merged upstream
- Fixes git/gtk warnings caused due to null defaults being set upstream