### PR TITLE
modules(home): move git.signing.format -> hm common config

### DIFF
--- a/home/user/common.nix
+++ b/home/user/common.nix
@@ -96,6 +96,7 @@ in
           };
         }
       ];
+      signing.format = "openpgp";
     };
 
     gpg = {

--- a/home/user/gibson.nix
+++ b/home/user/gibson.nix
@@ -123,7 +123,6 @@
       settings = {
         user.signingKey = "7D73BA8CF10F7F67";
       };
-      signing.format = "openpgp";
     };
 
     imv = {


### PR DESCRIPTION
-  `git.signing.format` was specifically added to hosts/gibson in #95 
- This has now been added to common hm configuration as darwin exhibits the same warning