### PR TITLE
features(home): symlinks - darwin updates

### DIFF
--- a/features/home/symlinks/module.nix
+++ b/features/home/symlinks/module.nix
@@ -17,7 +17,12 @@ in
       source = config.lib.file.mkOutOfStoreSymlink "${vars.syncthingPath}/Files/nix/gnupg/main.gpg";
     };
 
-    ".ssh" = lib.mkIf isLinux {
+    "Sync" = lib.mkIf isDarwin {
+      source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Library/Mobile Documents/com~apple~CloudDocs/Sync/";
+      recursive = true;
+    };
+
+    ".ssh" = {
       source = config.lib.file.mkOutOfStoreSymlink "${vars.syncthingPath}/Private/Keys";
       recursive = true;
     };


### PR DESCRIPTION
- this adds in a darwin-only link from local icloud cache -> $HOME/Sync
- the ssh symlink is now system-agonistic rather than linux-only