### PR TITLE
features(home): doomemacs - use inputs directly

### DIFF
--- a/features/home/doomemacs/module.nix
+++ b/features/home/doomemacs/module.nix
@@ -11,7 +11,7 @@
   lib,
   pkgs,
   vars,
-  doomemacs,
+  inputs,
   ...
 }:
 with lib;
@@ -66,10 +66,10 @@ mkMerge [
         ${pkgs.rsync}/bin/rsync -ogav --delete \
           --exclude '.local' --exclude '.cache' \
           --chmod=D2755,F744 ${rsyncChown} \
-          ${doomemacs}/ "$EMACSDIR/"
+          ${inputs.doomemacs}/ "$EMACSDIR/"
 
         stamp="${config.xdg.stateHome}/doom/sync-stamp"
-        key="${emacsPkg}|${doomemacs}"
+        key="${emacsPkg}|${inputs.doomemacs}"
 
         if [ ! -f "$stamp" ] || [ "$(cat "$stamp")" != "$key" ]; then
           echo "doom: inputs changed, running doom sync -u"

--- a/flake/parts/hosts/registry.nix
+++ b/flake/parts/hosts/registry.nix
@@ -106,7 +106,6 @@ in
               extraSpecialArgs = {
                 inherit inputs;
                 inherit (host) hostname vars;
-                inherit (inputs) doomemacs;
               }
               // extraSpecialArgs;
 


### PR DESCRIPTION
- removed doomemacs from extraSpecialArgs
- updated doomemacs module to reference inputs.doomemacs directly
- this avoids duplicate injection alongside existing inputs
- it also simplifies the module argument surface