### PR TITLE
flake(lib): cleanup mk-vars helper

### DIFF
--- a/flake/lib/mk-vars.nix
+++ b/flake/lib/mk-vars.nix
@@ -11,7 +11,7 @@
       homePrefix = if isDarwin then "/Users" else "/home";
     in
     {
-      inherit username hostname system;
+      inherit username;
       flakeSource = inputs.self;
       secretsPath = builtins.toString inputs.nix-secrets;
       syncthingPath = "${homePrefix}/${username}/Sync";


### PR DESCRIPTION
- removes hostname and system from being inherited by the vars set
- this fixes variable duplication supplied by the mk-vars helper