### PR TITLE
hosts(macbook): remove mailutils override

### DIFF
--- a/hosts/macbook/overlays/default.nix
+++ b/hosts/macbook/overlays/default.nix
@@ -9,13 +9,6 @@
 {
   nixpkgs.overlays = [
     (final: prev: {
-      # Can be rm'd once upstream merge lands in nixos-unstable (https://nixpk.gs/pr-tracker.html?pr=503376)
-      mailutils = prev.mailutils.overrideAttrs (old: {
-        nativeCheckInputs = builtins.filter (pkg: pkg != prev.nss_wrapper) (old.nativeCheckInputs or [ ]);
-
-        preCheck = "";
-        doCheck = false;
-      });
     })
   ];
 }


### PR DESCRIPTION
- This revokes the override added in ab98b45 (#96)
- nixpkgs has the fixed merged upstream