### PR TITLE
feature(home): doom - ignore sync update prompts

### DIFF
--- a/features/home/doomemacs/module.nix
+++ b/features/home/doomemacs/module.nix
@@ -72,8 +72,8 @@ mkMerge [
         key="${emacsPkg}|${inputs.doomemacs}"
 
         if [ ! -f "$stamp" ] || [ "$(cat "$stamp")" != "$key" ]; then
-          echo "doom: inputs changed, running doom sync -u"
-          "${config.xdg.configHome}/emacs/bin/doom" sync -u
+          echo "doom: inputs changed, running doom sync -u --force"
+          "${config.xdg.configHome}/emacs/bin/doom" sync -u --force
           echo "$key" > "$stamp"
 
           ${lib.optionalString pkgs.stdenv.hostPlatform.isDarwin ''


### PR DESCRIPTION
- this adds the --force option to the doom sync -u cmd
- updates can now apply without interaction