### PR TITLE
feat(syncthing): refactor to modular HM topology

### DIFF
--- a/features/home/sops-nix/module.nix
+++ b/features/home/sops-nix/module.nix
@@ -25,6 +25,21 @@
         path = "${config.xdg.configHome}/rbw/config.json";
       };
 
+      ## syncthing
+      "services/syncthing/user" = { };
+      "services/syncthing/pass" = { };
+      "services/syncthing/token" = { };
+
+      syncthing-cert = {
+        format = "binary";
+        sopsFile = "${vars.secretsPath}/secrets/syncthing/syncthing.enc.cert";
+      };
+
+      syncthing-key = {
+        format = "binary";
+        sopsFile = "${vars.secretsPath}/secrets/syncthing/syncthing.enc.key";
+      };
+
       "services/chatgpt/api_key" = { };
     };
   };

--- a/features/home/syncthing/default.nix
+++ b/features/home/syncthing/default.nix
@@ -1,0 +1,3 @@
+_: {
+  flake.modules.homeManager.syncthing = ./module.nix;
+}

--- a/features/home/syncthing/linux-bootstrap.nix
+++ b/features/home/syncthing/linux-bootstrap.nix
@@ -1,0 +1,140 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    filterAttrs
+    concatMapStringsSep
+    escapeShellArg
+    ;
+
+  cfg = config.features.home.syncthing;
+
+  bootstrapFolders = filterAttrs (_: f: f.enable && f.bootstrap.enable) cfg.folders;
+
+  firstBootstrapFolder = builtins.head (builtins.attrNames bootstrapFolders);
+
+  folderCfg = bootstrapFolders.${firstBootstrapFolder};
+
+  inherit (folderCfg.bootstrap) markerFile;
+  folderPath = folderCfg.path;
+
+  syncthingConfigFile = "${config.home.homeDirectory}/.local/state/syncthing/config.xml";
+in
+{
+  config = mkIf (pkgs.stdenv.isLinux && bootstrapFolders != { }) {
+    systemd.user.services.syncthing-bootstrap = {
+      Unit = {
+        Description = "Safe first-sync bootstrap for Syncthing";
+        Wants = [
+          "syncthing.service"
+          "syncthing-init.service"
+        ];
+        After = [
+          "syncthing.service"
+          "syncthing-init.service"
+        ];
+        ConditionPathExists = "!${markerFile}";
+      };
+
+      Service = {
+        Type = "oneshot";
+        TimeoutStartSec = "90s";
+        ExecStart = pkgs.writeShellScript "syncthing-bootstrap-start" ''
+          set -euo pipefail
+
+          marker=${escapeShellArg markerFile}
+          folder_path=${escapeShellArg folderPath}
+          config_file=${escapeShellArg syncthingConfigFile}
+
+          mkdir -p "$folder_path/.stfolder"
+          mkdir -p "$(dirname "$marker")"
+
+          for _ in $(seq 1 30); do
+            [ -f "$config_file" ] && break
+            sleep 2
+          done
+
+          [ -f "$config_file" ] || {
+            echo "Timed out waiting for Syncthing config at $config_file"
+            exit 1
+          }
+
+          token="$(
+            sed -n 's:.*<apikey>\(.*\)</apikey>.*:\1:p' "$config_file" | head -n1
+          )"
+
+          [ -n "$token" ] || {
+            echo "Failed to read Syncthing API key from $config_file"
+            exit 1
+          }
+
+          api_base="http://127.0.0.1:8384"
+          curl_extra=()
+
+          if ! ${pkgs.curl}/bin/curl -fsS "$api_base/rest/noauth/health" >/dev/null 2>&1; then
+            api_base="https://127.0.0.1:8384"
+            curl_extra=(-k)
+          fi
+
+          for _ in $(seq 1 30); do
+            if ${pkgs.curl}/bin/curl "''${curl_extra[@]}" -fsS "$api_base/rest/noauth/health" >/dev/null 2>&1; then
+              break
+            fi
+            sleep 2
+          done
+
+          ${pkgs.curl}/bin/curl "''${curl_extra[@]}" -fsS \
+            -X PATCH \
+            -H "Authorization: Bearer $token" \
+            -H "Content-Type: application/json" \
+            "$api_base/rest/config/folders/sync" \
+            --data '{"type":"receiveonly"}' >/dev/null
+
+          ${pkgs.curl}/bin/curl "''${curl_extra[@]}" -fsS \
+            -X POST \
+            -H "Authorization: Bearer $token" \
+            "$api_base/rest/db/scan?folder=sync" >/dev/null
+
+          sleep 2
+
+          ${pkgs.curl}/bin/curl "''${curl_extra[@]}" -fsS \
+            -X POST \
+            -H "Authorization: Bearer $token" \
+            "$api_base/rest/db/revert?folder=sync" >/dev/null
+
+          for _ in $(seq 1 60); do
+            completion="$(
+              ${pkgs.curl}/bin/curl "''${curl_extra[@]}" -fsS \
+                -H "Authorization: Bearer $token" \
+                "$api_base/rest/db/completion?folder=sync" \
+              | ${pkgs.jq}/bin/jq -r '.completion'
+            )"
+
+            completion_int="''${completion%.*}"
+
+            [ "$completion_int" -ge 100 ] && break
+            sleep 2
+          done
+
+          ${pkgs.curl}/bin/curl "''${curl_extra[@]}" -fsS \
+            -X PATCH \
+            -H "Authorization: Bearer $token" \
+            -H "Content-Type: application/json" \
+            "$api_base/rest/config/folders/sync" \
+            --data '{"type":"sendreceive"}' >/dev/null
+
+          touch "$marker"
+        '';
+      };
+
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+    };
+  };
+}

--- a/features/home/syncthing/module.nix
+++ b/features/home/syncthing/module.nix
@@ -1,0 +1,216 @@
+{
+  lib,
+  config,
+  pkgs,
+  vars,
+  hostname,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    types
+    mapAttrs
+    filterAttrs
+    optional
+    optionalAttrs
+    attrNames
+    concatLists
+    any
+    hasAttr
+    nameValuePair
+    ;
+
+  topology = import ./topology.nix;
+
+  cfg = config.features.home.syncthing;
+
+  host = if cfg.deviceName != null then cfg.deviceName else hostname;
+
+  hostDevice =
+    topology.devices.${host}
+      or (throw "features.home.syncthing.deviceName '${host}' does not exist in features/home/syncthing/topology.nix");
+
+  enabledFolders = filterAttrs (_: f: f.enable) cfg.folders;
+
+  allPeerNames = lib.unique (lib.concatLists (lib.mapAttrsToList (_: f: f.peers) enabledFolders));
+
+  peerDevices = mapAttrs (
+    _: dev:
+    {
+      inherit (dev) id autoAcceptFolders introducer;
+    }
+    // optionalAttrs (dev ? addresses) {
+      inherit (dev) addresses;
+    }
+  ) (filterAttrs (name: _: builtins.elem name allPeerNames) topology.devices);
+
+  renderedFolders = lib.mapAttrs' (
+    folderName: folderCfg:
+    let
+      topoFolder =
+        topology.folders.${folderName}
+          or (throw "Syncthing folder '${folderName}' not found in shared topology");
+
+      missingPeers = builtins.filter (peer: !(topology.devices ? ${peer})) folderCfg.peers;
+    in
+    if missingPeers != [ ] then
+      throw "Syncthing folder '${folderName}' on host '${host}' references unknown peer(s): ${builtins.concatStringsSep ", " missingPeers}"
+    else
+      nameValuePair folderCfg.path {
+        inherit (topoFolder) id label;
+        inherit (folderCfg) path type;
+        devices = folderCfg.peers;
+      }
+  ) enabledFolders;
+
+  anyBootstrapEnabled = any (f: f.bootstrap.enable) (builtins.attrValues enabledFolders);
+in
+{
+
+  imports = [
+    ./linux-bootstrap.nix
+  ];
+
+  options.features.home.syncthing = {
+    enable = mkEnableOption "Declarative Syncthing";
+
+    deviceName = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Device name key used in shared Syncthing topology. Defaults to hostname.";
+    };
+
+    gui = {
+      address = mkOption {
+        type = types.str;
+        default = "127.0.0.1:8384";
+      };
+
+      tls = mkOption {
+        type = types.bool;
+        default = true;
+      };
+
+      theme = mkOption {
+        type = types.str;
+        default = "dark";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = vars.username;
+      };
+    };
+
+    folders = mkOption {
+      type = types.attrsOf (
+        types.submodule (
+          { name, ... }:
+          {
+            options = {
+              enable = mkEnableOption "Syncthing folder ${name}" // {
+                default = true;
+              };
+
+              path = mkOption {
+                type = types.str;
+                description = "Local path for Syncthing folder ${name}.";
+              };
+
+              type = mkOption {
+                type = types.enum [
+                  "sendreceive"
+                  "receiveonly"
+                  "sendonly"
+                  "receiveencrypted"
+                ];
+                default = "sendreceive";
+              };
+
+              peers = mkOption {
+                type = types.listOf types.str;
+                default = [ ];
+                description = "Device names from shared topology that this host shares folder ${name} with.";
+              };
+
+              bootstrap = {
+                enable = mkOption {
+                  type = types.bool;
+                  default = false;
+                };
+
+                markerFile = mkOption {
+                  type = types.str;
+                  default = "${config.home.homeDirectory}/.local/state/syncthing-bootstrap/${name}.ready";
+                };
+              };
+            };
+          }
+        )
+      );
+      default = { };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      assertions = [
+        {
+          assertion = topology.devices ? ${host};
+          message = "features.home.syncthing.deviceName '${host}' must exist in shared Syncthing topology.";
+        }
+      ];
+
+      home.packages = with pkgs; [
+        syncthing
+        curl
+        jq
+      ];
+
+      services.syncthing = {
+        enable = true;
+
+        cert = config.sops.secrets."syncthing-cert".path;
+        key = config.sops.secrets."syncthing-key".path;
+
+        passwordFile = config.sops.secrets."services/syncthing/pass".path;
+        guiAddress = cfg.gui.address;
+
+        overrideFolders = true;
+        overrideDevices = false;
+
+        settings = {
+          options = {
+            urAccepted = -1;
+            relaysEnabled = false;
+            localAnnounceEnabled = true;
+            globalAnnounceEnabled = false;
+          };
+
+          gui = {
+            inherit (cfg.gui) user tls theme;
+          };
+
+          devices = peerDevices;
+          folders = renderedFolders;
+        };
+      };
+    }
+
+    (mkIf
+      (!pkgs.stdenv.isLinux && builtins.any (f: f.bootstrap.enable) (builtins.attrValues enabledFolders))
+      {
+        assertions = [
+          {
+            assertion = false;
+            message = "Syncthing bootstrap is enabled for this host, but only the Linux bootstrap helper exists currently.";
+          }
+        ];
+      }
+    )
+  ]);
+}

--- a/features/home/syncthing/topology.nix
+++ b/features/home/syncthing/topology.nix
@@ -1,0 +1,31 @@
+{
+  devices = {
+    gibson = {
+      id = "7VDI5S5-BHDGS6M-HOD26MV-DYVHJ7Z-WJQ3RKA-NI5UWP7-BRXWYKF-DLJYAQ4";
+      addresses = [ "dynamic" ];
+      autoAcceptFolders = false;
+      introducer = false;
+    };
+
+    syncMaster = {
+      id = "NFYVMXE-T3IVMTV-UMLRBZ3-RQ246DT-QV3CCRG-45W5D23-EYFQFNY-Z6AH7QH";
+      addresses = [ "tcp://192.168.1.165:22000" ];
+      autoAcceptFolders = true;
+      introducer = false;
+    };
+
+    macbook = {
+      id = "G4QTXBM-ZNDISJJ-L6D3NQG-EDKOJLA-YOOFPSG-PRGCXZV-3RVVZWH-2I3XDAE";
+      addresses = [ "dynamic" ];
+      autoAcceptFolders = false;
+      introducer = false;
+    };
+  };
+
+  folders = {
+    sync = {
+      id = "sync";
+      label = "Sync";
+    };
+  };
+}

--- a/flake/parts/features.nix
+++ b/flake/parts/features.nix
@@ -23,9 +23,11 @@
     ./../../features/home/playerctld
     ./../../features/home/qutebrowser
     ./../../features/home/sops-nix
+    ./../../features/home/syncthing
     ./../../features/home/symlinks
     ./../../features/home/waybar
     ./../../features/home/wayland-idle-inhibit
     ./../../features/home/xdg-portal-hyprland
+
   ];
 }

--- a/hosts/gibson/home.nix
+++ b/hosts/gibson/home.nix
@@ -3,6 +3,7 @@
   lib,
   inputs,
   vars,
+  hostname,
   pkgs,
   ...
 }:
@@ -110,6 +111,21 @@
     home = {
       mako = {
         output = "DP-1";
+      };
+      syncthing = {
+        enable = true;
+        deviceName = "${hostname}";
+
+        folders.sync = {
+          enable = true;
+          path = vars.syncthingPath;
+          type = "sendreceive";
+          peers = [ "syncMaster" ];
+
+          bootstrap = {
+            enable = true;
+          };
+        };
       };
     };
   };

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -52,6 +52,7 @@ in
     users."${vars.username}" = {
       isNormalUser = true;
       description = "${vars.username}";
+      linger = true;
       extraGroups = [
         "networkmanager"
         "wheel"
@@ -97,17 +98,6 @@ in
       ];
     };
     services = {
-      "configureSyncthing" = {
-        enable = true;
-        description = "Sets up syncthing for new installs";
-        path = with pkgs; [
-          jq
-          curl
-          gawk
-        ];
-        wantedBy = [ "syncthing.service" ];
-        script = "${pkgs.bash}/bin/bash ${config.sops.templates."configureSyncting.service".path}";
-      };
       "nix-daemon" = {
         environment = {
           TMPDIR = "/nix/tmp";
@@ -286,51 +276,6 @@ in
       settings = {
         Login = {
           HandleHibernateKey = "ignore";
-        };
-      };
-    };
-
-    syncthing = {
-      enable = true;
-      user = "${vars.username}";
-      dataDir = "${vars.syncthingPath}";
-      configDir = "/home/${vars.username}/.config/syncthing";
-      openDefaultPorts = true;
-      overrideDevices = true; # overrides any devices added or deleted through the WebUI
-
-      key = config.sops.secrets."syncthing-key".path;
-      cert = config.sops.secrets."syncthing-cert".path;
-
-      settings = {
-        options = {
-          urAccepted = -1;
-          relaysEnabled = false;
-          globalAnnounceEnabled = false;
-        };
-
-        gui = {
-          user = config.sops.secrets."services/syncthing/user";
-          password = config.sops.secrets."services/syncthing/pass";
-          apikey = config.sops.secrets."services/syncthing/token";
-          theme = "dark";
-          tls = true;
-        };
-
-        devices = {
-          "SyncMaster" = {
-            id = "NFYVMXE-T3IVMTV-UMLRBZ3-RQ246DT-QV3CCRG-45W5D23-EYFQFNY-Z6AH7QH";
-            autoAcceptFolders = true;
-          };
-        };
-
-        folders = {
-          "${vars.syncthingPath}" = {
-            path = "${vars.syncthingPath}";
-            devices = [ "SyncMaster" ];
-            id = "sync";
-            label = "Sync";
-            type = "receiveonly";
-          };
         };
       };
     };
@@ -523,22 +468,6 @@ in
     defaultSopsFormat = "yaml";
 
     secrets = {
-      ## syncthing
-      "services/syncthing/user" = { };
-      "services/syncthing/pass" = { };
-      "services/syncthing/token" = { };
-
-      syncthing-cert = {
-        format = "binary";
-        sopsFile = "${vars.secretsPath}/secrets/syncthing/syncthing.enc.cert";
-        owner = "${vars.username}";
-      };
-
-      syncthing-key = {
-        format = "binary";
-        sopsFile = "${vars.secretsPath}/secrets/syncthing/syncthing.enc.key";
-        owner = "${vars.username}";
-      };
 
       # Yubikey
       "system/pam/yubikeyPub" = {
@@ -551,100 +480,6 @@ in
       };
     };
 
-    templates = {
-      "configureSyncting.service" = {
-        content = ''
-          ## THIS TOOK HOURS OF MY FUCKING LIFE MAN
-
-          DIR=${vars.syncthingPath}
-          TOKEN=${config.sops.placeholder."services/syncthing/token"}
-
-          function checkSync {
-              export SYNC_PERCENTAGE=$(curl -s -X GET -H "Authorization: Bearer $TOKEN" http://localhost:8384/rest/db/completion?folder=sync | jq '."completion"' | awk -F. '{print $1}')
-          }
-
-          function waitSync {
-              checkSync
-              while [[ $SYNC_PERCENTAGE -lt 100 ]]
-              do
-                  sleep 15
-                  checkSync
-                  echo "Sync is at $SYNC_PERCENTAGE%"
-              done
-              if [[ $SYNC_PERCENTAGE -eq 100 ]]; then
-                  echo "Synthing setup has finished. Switch builds to ensure all secrets are included."
-                  curl -s -X PATCH -H "Authorization: Bearer $TOKEN" http://localhost:8384/rest/config/folders/sync --data '{"type": "sendreceive"}'
-              else
-                  echo "Sync appears to have finished synching but there's an issue. Please check it out."
-                  fi
-          }
-
-          function syncFix {
-              # ENSURE that the local folder is set to "Receive Only" - it is by default.
-              echo "Setting local folder to receive only"
-              receiveOnly
-              echo "Beginning Sync. Please wait..."
-              sleep 15
-              syncRevert
-              sleep 15
-              waitSync
-          }
-
-          function syncRevert {
-              curl -s -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8384/rest/db/scan?folder=sync
-              sleep 2
-              curl -s -X POST -H "Authorization: Bearer $TOKEN" http://localhost:8384/rest/db/revert?folder=sync
-
-          }
-
-          function receiveOnly {
-              curl -s -X PATCH -H "Authorization: Bearer $TOKEN" http://localhost:8384/rest/config/folders/sync --data '{"type": "receiveonly"}'
-          }
-
-          function sendReceive {
-              curl -s -o /dev/null -w "%{http_code}" -X PATCH -H "Authorization: Bearer $TOKEN" http://localhost:8384/rest/config/folders/sync --data '{"type": "sendreceive"}'
-          }
-
-          sleep 5
-          echo "Starting..."
-          if [ ! -d "$DIR" ]; then
-              echo "No sync folder detected. Configuring..."
-
-              receiveOnly
-              mkdir -p $DIR/.stfolder
-              echo "Directory created."
-              chown -R ${vars.username}:users $DIR
-              echo "Permissions Set."
-              sleep 2
-
-              STATUS=$(curl -s -X GET http://localhost:8384/rest/noauth/health | jq -r '."status"')
-              echo "Status reports as: $STATUS"
-
-              if [ "$STATUS" == "OK" ]; then
-                echo "Starting Sync Fix"
-                syncFix
-              else
-                echo "Check the service status of Syncthing. It shows as: $STATUS"
-              fi
-
-          else
-            receiveOnly
-            syncRevert
-            sleep 10
-            checkSync
-            if [[ $SYNC_PERCENTAGE -ne 100 ]]; then
-              echo "Starting Sync Fix"
-              syncFix
-            else
-              echo "Everything looks like it's already setup! Setting folder to Send/Receive mode.."
-              sendReceive
-              echo "All done!"
-            fi
-
-          fi
-        '';
-      };
-    };
   };
 
   # This value determines the NixOS release from which the default settings for stateful data, like file locations and database versions on your system were taken. It‘s perfectly fine and recommended to leave this value at the

--- a/profiles/home/darwin.nix
+++ b/profiles/home/darwin.nix
@@ -4,6 +4,7 @@
     inputs.mac-app-util.homeManagerModules.default
     inputs.self.modules.homeManager.doomemacs
     inputs.self.modules.homeManager.qutebrowser
+    inputs.self.modules.homeManager.sops-nix
     inputs.self.modules.homeManager.symlinks
   ];
 }

--- a/profiles/home/desktop.nix
+++ b/profiles/home/desktop.nix
@@ -1,6 +1,7 @@
 { inputs, pkgs, ... }:
 {
   imports = [
+    # Home-Manager
     inputs.wayland-pipewire-idle-inhibit.homeModules.default
     inputs.self.modules.homeManager.doomemacs
     inputs.self.modules.homeManager.fuzzel
@@ -20,6 +21,7 @@
     inputs.self.modules.homeManager.waybar
     inputs.self.modules.homeManager.wayland-idle-inhibit
     inputs.self.modules.homeManager.xdg-portal-hyprland
+    inputs.self.modules.homeManager.syncthing
   ];
 
   home.packages = [


### PR DESCRIPTION
A chonky PR that _attempts_ to make syncthing config more modular.

This will:

- move syncthing config to a feature/home module
- introduce shared topology (for devices + folders)
- switch to host-local peer definitions (hub-and-spoke)
- add optional Linux bootstrap for safe first sync
- remove existing/legacy system-level integration

This preserves the existing Gibson/Syncthing functionality.
Further work/cleanup needs doing to incorporate Macbook.