### PR TITLE
flake(input): pin gibson kernel to nixpkgs revision

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -458,6 +458,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-qutebrowser-fix": {
+      "locked": {
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1775002709,
@@ -649,6 +665,7 @@
         "nixpkgs": "nixpkgs_7",
         "nixpkgs-darwin": "nixpkgs-darwin",
         "nixpkgs-old": "nixpkgs-old",
+        "nixpkgs-qutebrowser-fix": "nixpkgs-qutebrowser-fix",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "qute-dracula": "qute-dracula",
         "sops-nix": "sops-nix",

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-old.url = "github:nixos/nixpkgs/nixos-25.05";
     nixpkgs-darwin.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs-qutebrowser-fix.url = "github:NixOS/nixpkgs/b40629efe5d6ec48dd1efba650c797ddbd39ace0";
 
     # nix-darwin / mac related
     nix-darwin.url = "github:LnL7/nix-darwin";

--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -5,18 +5,26 @@
   config,
   lib,
   pkgs,
+  inputs,
   modulesPath,
   system,
   vars,
   ...
 }:
+let
+  qutebrowser-fix = import inputs.nixpkgs-qutebrowser-fix {
+    inherit (pkgs.stdenv.hostPlatform) system;
+    config.allowUnfree = true;
+  };
+in
 {
   imports = [
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
   boot = {
-    kernelPackages = pkgs.linuxPackages_xanmod;
+    #kernelPackages = pkgs.linuxPackages_xanmod;
+    kernelPackages = qutebrowser-fix.linuxPackages_xanmod;
     kernelModules = [
       "nvidia"
       "nvidia_modeset"
@@ -111,6 +119,20 @@
 
   hardware = {
     enableAllFirmware = true;
+
+    graphics = {
+      enable = true;
+      enable32Bit = true;
+      extraPackages = with pkgs; [ nvidia-vaapi-driver ]; # For additional packages if needed
+    };
+
+    nvidia = {
+      modesetting.enable = true;
+      open = true;
+      powerManagement.enable = true;
+      nvidiaSettings = true;
+      package = config.boot.kernelPackages.nvidiaPackages.production;
+    };
   };
 
   networking.useDHCP = lib.mkDefault true;

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -439,20 +439,6 @@ in
       };
     };
 
-    graphics = {
-      enable = true;
-      enable32Bit = true;
-      extraPackages = with pkgs; [ nvidia-vaapi-driver ]; # For additional packages if needed
-    };
-
-    nvidia = {
-      modesetting.enable = true;
-      open = true;
-      powerManagement.enable = true;
-      nvidiaSettings = true;
-      package = config.boot.kernelPackages.nvidiaPackages.stable;
-    };
-
     bluetooth = {
       enable = true;
       powerOnBoot = true;


### PR DESCRIPTION
- following the most recent flake update qutebrowser on gibson has some issues
- this adds a new flake input to pin the last known working nixpkgs revision
- gibson kernel (and inherently gfx stack) have been pinned to this revision
- nvidia/graphics hardware settings have moved from system.nix -> hardware-configuration.nix