### PR TITLE
host(macbook): adds syncthing/sops-nix modules

### DIFF
--- a/features/home/sops-nix/module.nix
+++ b/features/home/sops-nix/module.nix
@@ -4,16 +4,21 @@
   pkgs,
   inputs,
   vars,
+  hostname,
   ...
 }:
 {
+  home.packages = with pkgs; [
+    sops
+    age
+    age-plugin-yubikey
+    yubikey-manager
+  ];
+
   sops = {
-    age.keyFile = "/var/lib/age/keys.txt";
+    age.keyFile = "${vars.age.keyFile}";
     defaultSopsFile = "${vars.secretsPath}/secrets/secrets.yaml";
     defaultSopsFormat = "yaml";
-
-    defaultSymlinkPath = "/run/user/1000/secrets";
-    defaultSecretsMountPoint = "/run/user/1000/secrets.d";
 
     secrets = {
       "services/jellyfin/creds" = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
@@ -26,21 +31,17 @@
       };
 
       ## syncthing
-      "services/syncthing/user" = { };
       "services/syncthing/pass" = { };
-      "services/syncthing/token" = { };
 
       syncthing-cert = {
         format = "binary";
-        sopsFile = "${vars.secretsPath}/secrets/syncthing/syncthing.enc.cert";
+        sopsFile = "${vars.secretsPath}/secrets/syncthing/${hostname}.cert";
       };
 
       syncthing-key = {
         format = "binary";
-        sopsFile = "${vars.secretsPath}/secrets/syncthing/syncthing.enc.key";
+        sopsFile = "${vars.secretsPath}/secrets/syncthing/${hostname}.key";
       };
-
-      "services/chatgpt/api_key" = { };
     };
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -331,11 +331,11 @@
     "nix-secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1768168482,
-        "narHash": "sha256-+VXI+h+daSAHYmF3CVLOVTOthzvaKAUAD/Ti/PW3ecM=",
+        "lastModified": 1776171393,
+        "narHash": "sha256-Yd7a/BL4cFIl5q4xn0FrpduKXj8DmLY0Gf2n3vRImhE=",
         "ref": "main",
-        "rev": "c7e5540e40c8d0677e0a4f9ea46f2667743b5604",
-        "revCount": 17,
+        "rev": "b90e93cc5964a15e00f4f178fccd69c2b4047445",
+        "revCount": 20,
         "type": "git",
         "url": "ssh://git@github.com/5ysk3y/nix-secrets.git"
       },

--- a/flake/lib/mk-vars.nix
+++ b/flake/lib/mk-vars.nix
@@ -9,11 +9,17 @@
     let
       isDarwin = builtins.match ".*-darwin" system != null;
       homePrefix = if isDarwin then "/Users" else "/home";
+      ageKeyFile =
+        if isDarwin then
+          "${homePrefix}/${username}/Library/Application Support/sops/age/keys.txt"
+        else
+          "/var/lib/age/keys.txt";
     in
     {
       inherit username;
       flakeSource = inputs.self;
       secretsPath = builtins.toString inputs.nix-secrets;
       syncthingPath = "${homePrefix}/${username}/Sync";
+      age.keyFile = "${ageKeyFile}";
     };
 }

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -65,7 +65,7 @@ in
       #   packages = with pkgs; [    ];
       #   USER PKGS MANAGED IN HOME.NIX
       shell = pkgs.zsh;
-      hashedPasswordFile = config.sops.secrets."hosts/user_pass".path;
+      hashedPasswordFile = config.sops.secrets."system/gibson_user_pass".path;
     };
     groups = {
       sops = { };
@@ -449,7 +449,7 @@ in
   };
 
   sops = {
-    age.keyFile = "/var/lib/age/keys.txt";
+    age.keyFile = "${vars.age.keyFile}";
     defaultSopsFile = "${vars.secretsPath}/secrets/secrets.yaml";
     defaultSopsFormat = "yaml";
 
@@ -461,7 +461,7 @@ in
       };
 
       # System
-      "hosts/user_pass" = {
+      "system/gibson_user_pass" = {
         neededForUsers = true;
       };
     };

--- a/hosts/macbook/home.nix
+++ b/hosts/macbook/home.nix
@@ -4,6 +4,7 @@
   pkgs,
   inputs,
   vars,
+  hostname,
   ...
 }:
 {
@@ -41,6 +42,22 @@
     gpg-agent = {
       pinentry = {
         package = pkgs.pinentry_mac;
+      };
+    };
+  };
+
+  features = {
+    home = {
+      syncthing = {
+        enable = true;
+        deviceName = "${hostname}";
+
+        folders.sync = {
+          enable = true;
+          path = vars.syncthingPath;
+          type = "receiveonly";
+          peers = [ "syncMaster" ];
+        };
       };
     };
   };

--- a/profiles/home/darwin.nix
+++ b/profiles/home/darwin.nix
@@ -6,5 +6,6 @@
     inputs.self.modules.homeManager.qutebrowser
     inputs.self.modules.homeManager.sops-nix
     inputs.self.modules.homeManager.symlinks
+    inputs.self.modules.homeManager.syncthing
   ];
 }


### PR DESCRIPTION
In no particular order, this:

- Moves away from my existing macbook/imperative syncthing implementation
- Incorperates the new `features/home/syncthing` module in its place
- Intergrates existing sops-nix secrets model with Darwin
- Adds/updates some secret names accordingly
- Updates the flake.lock to use the latest secrets tree.
- Adds a new per-system variable to define sops' age key file location