### PR TITLE
host(gibson): kernel switch/pin + sddm/pam update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,17 +460,17 @@
     },
     "nixpkgs-qutebrowser-fix": {
       "locked": {
-        "lastModified": 1773821835,
-        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "lastModified": 1774476476,
+        "narHash": "sha256-wwnVrY2pc5U/nZFEZpRQ634q+gQ3aPr3bIbeou8M9kk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "rev": "4ceb3f35581a8ed908a21284105617d32ac59505",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "rev": "4ceb3f35581a8ed908a21284105617d32ac59505",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-old.url = "github:nixos/nixpkgs/nixos-25.05";
     nixpkgs-darwin.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    nixpkgs-qutebrowser-fix.url = "github:NixOS/nixpkgs/b40629efe5d6ec48dd1efba650c797ddbd39ace0";
+    nixpkgs-qutebrowser-fix.url = "github:NixOS/nixpkgs/4ceb3f35581a8ed908a21284105617d32ac59505";
 
     # nix-darwin / mac related
     nix-darwin.url = "github:LnL7/nix-darwin";

--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -23,8 +23,8 @@ in
   ];
 
   boot = {
-    #kernelPackages = pkgs.linuxPackages_xanmod;
-    kernelPackages = qutebrowser-fix.linuxPackages_xanmod;
+    #kernelPackages = pkgs.linuxPackages_zen;
+    kernelPackages = qutebrowser-fix.linuxPackages_zen;
     kernelModules = [
       "nvidia"
       "nvidia_modeset"
@@ -131,7 +131,7 @@ in
       open = true;
       powerManagement.enable = true;
       nvidiaSettings = true;
-      package = config.boot.kernelPackages.nvidiaPackages.production;
+      package = config.boot.kernelPackages.nvidiaPackages.stable;
     };
   };
 

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -182,7 +182,7 @@ in
 
         sddm = {
           text = ''
-            auth     sufficient    pam_u2f.so  cue
+            auth     sufficient    pam_u2f.so  cue   origin=pam://gibson appid=pam://gibson
             auth     include       login
             account  include       login
             password include       login


### PR DESCRIPTION
- Moved gibson from xanmod to zen (its time to do the kernel hop)
- Kernel pinned to `6.19.9-zen1` and, inherently, NVIDIA `580.142`
- Made a minor adjustment to the PAM/SDDM config