### PR TITLE
feature(home): add multi-platform ghostty module

### DIFF
--- a/features/home/ghostty/default.nix
+++ b/features/home/ghostty/default.nix
@@ -1,0 +1,3 @@
+_: {
+  flake.modules.homeManager.ghostty = ./module.nix;
+}

--- a/features/home/ghostty/module.nix
+++ b/features/home/ghostty/module.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  programs = {
+    ghostty = {
+      enable = true;
+      package = if pkgs.stdenv.hostPlatform.isDarwin then pkgs.ghostty-bin else pkgs.ghostty;
+      enableZshIntegration = true;
+      installVimSyntax = true;
+      settings = {
+        theme = "dracula";
+        font-size = 14;
+        macos-option-as-alt = "left";
+      };
+    };
+  };
+}

--- a/flake/parts/features.nix
+++ b/flake/parts/features.nix
@@ -12,6 +12,7 @@
     ./../../features/home/doomemacs
     ./../../features/home/fuzzel
     ./../../features/home/gaming
+    ./../../features/home/ghostty
     ./../../features/home/gtk-dracula
     ./../../features/home/hypr
     ./../../features/home/kitty

--- a/profiles/home/darwin.nix
+++ b/profiles/home/darwin.nix
@@ -3,6 +3,7 @@
   imports = [
     inputs.mac-app-util.homeManagerModules.default
     inputs.self.modules.homeManager.doomemacs
+    inputs.self.modules.homeManager.ghostty
     inputs.self.modules.homeManager.qutebrowser
     inputs.self.modules.homeManager.sops-nix
     inputs.self.modules.homeManager.symlinks


### PR DESCRIPTION
- Adds an additional ghostty shell client usable as a home-manager feature module
- This will gate the installed package depending on system type
- Macbook has now got this included over an imperative install of ghostty
- Preferred settings have been retained as defaults (theme etc)