### PR TITLE
feature(home): home packages rework + emacs LSP

### DIFF
--- a/features/home/core/base.nix
+++ b/features/home/core/base.nix
@@ -1,18 +1,19 @@
-_: {
-  flake.modules.homeManager.base =
-    { vars, ... }:
-    {
-      home = {
-        inherit (vars) username;
+{ vars, pkgs, ... }:
+{
+  home = {
+    inherit (vars) username;
 
-        sessionVariables = {
-          GIT_AUTO_FETCH_INTERVAL = 1200;
-          NIXOS_CONFIG = "$HOME/nixos-config";
-        };
+    packages = with pkgs; [
+      bat
+    ];
 
-        stateVersion = "23.11";
-      };
-
-      programs.home-manager.enable = true;
+    sessionVariables = {
+      GIT_AUTO_FETCH_INTERVAL = 1200;
+      NIXOS_CONFIG = "$HOME/nixos-config";
     };
+
+    stateVersion = "23.11";
+  };
+
+  programs.home-manager.enable = true;
 }

--- a/features/home/core/default.nix
+++ b/features/home/core/default.nix
@@ -1,0 +1,9 @@
+_: {
+  flake.modules.homeManager = {
+    base = ./base.nix;
+    git = ./git.nix;
+    gpg = ./gpg.nix;
+    zoxide = ./zoxide.nix;
+    zsh = ./zsh.nix;
+  };
+}

--- a/features/home/core/git.nix
+++ b/features/home/core/git.nix
@@ -1,36 +1,34 @@
 _: {
-  flake.modules.homeManager.git = _: {
-    programs.git = {
-      enable = true;
+  programs.git = {
+    enable = true;
 
-      settings = {
-        user = {
-          name = "5ysk3y";
-          email = "62815243+5ysk3y@users.noreply.github.com";
-        };
-
-        alias = {
-          newpr = "!f() { git fetch origin -p && git checkout -B \"$1\" origin/main && git branch --unset-upstream; }; f";
-          st = "!git status";
-        };
-
-        push = {
-          default = "current";
-          autoSetupRemote = true;
-        };
-
-        branch.autoSetupMerge = true;
-        commit.gpgsign = true;
+    settings = {
+      user = {
+        name = "5ysk3y";
+        email = "62815243+5ysk3y@users.noreply.github.com";
       };
 
-      includes = [
-        {
-          condition = "gitdir:~/nixos-config/**";
-          contents.core.hooksPath = ".githooks";
-        }
-      ];
+      alias = {
+        newpr = "!f() { git fetch origin -p && git checkout -B \"$1\" origin/main && git branch --unset-upstream; }; f";
+        st = "!git status";
+      };
 
-      signing.format = "openpgp";
+      push = {
+        default = "current";
+        autoSetupRemote = true;
+      };
+
+      branch.autoSetupMerge = true;
+      commit.gpgsign = true;
     };
+
+    includes = [
+      {
+        condition = "gitdir:~/nixos-config/**";
+        contents.core.hooksPath = ".githooks";
+      }
+    ];
+
+    signing.format = "openpgp";
   };
 }

--- a/features/home/core/gpg.nix
+++ b/features/home/core/gpg.nix
@@ -1,28 +1,27 @@
-_: {
-  flake.modules.homeManager.gpg =
-    _:
-    let
-      ghKey = builtins.fetchurl {
-        url = "https://github.com/5ysk3y.gpg";
-        sha256 = "072875xvjay4ssx8g0a3f8cm51xsc4l63ls6xpjl7abzq29a5m9z";
-      };
-    in
-    {
-      programs.gpg.enable = true;
+_:
+let
+  ghKey = builtins.fetchurl {
+    url = "https://github.com/5ysk3y.gpg";
+    sha256 = "072875xvjay4ssx8g0a3f8cm51xsc4l63ls6xpjl7abzq29a5m9z";
+  };
+in
+{
+  programs.gpg = {
+    enable = true;
 
-      services.gpg-agent = {
-        enable = true;
-        enableSshSupport = true;
-        enableZshIntegration = true;
-        defaultCacheTtl = 600;
-        maxCacheTtl = 7200;
-      };
+    publicKeys = [
+      {
+        source = ghKey;
+        trust = 5;
+      }
+    ];
+  };
 
-      programs.gpg.publicKeys = [
-        {
-          source = ghKey;
-          trust = 5;
-        }
-      ];
-    };
+  services.gpg-agent = {
+    enable = true;
+    enableSshSupport = true;
+    enableZshIntegration = true;
+    defaultCacheTtl = 600;
+    maxCacheTtl = 7200;
+  };
 }

--- a/features/home/core/zoxide.nix
+++ b/features/home/core/zoxide.nix
@@ -1,12 +1,10 @@
 _: {
-  flake.modules.homeManager.zoxide = _: {
-    programs.zoxide = {
-      enable = true;
-      enableZshIntegration = true;
-      options = [
-        "--cmd"
-        "cd"
-      ];
-    };
+  programs.zoxide = {
+    enable = true;
+    enableZshIntegration = true;
+    options = [
+      "--cmd"
+      "cd"
+    ];
   };
 }

--- a/features/home/core/zsh.nix
+++ b/features/home/core/zsh.nix
@@ -1,30 +1,34 @@
 _: {
-  flake.modules.homeManager.zsh = _: {
-    programs.zsh = {
+  programs.zsh = {
+    enable = true;
+    autosuggestion.enable = true;
+
+    sessionVariables = {
+      GNUMAKEFLAGS = "-j12";
+      LESSHISTFILE = "-";
+    };
+
+    initContent = ''
+      vim() {
+        emacsclient -t "$@"
+      }
+    '';
+
+    shellAliases = {
+      less = "bat $@";
+      ll = "ls -lash";
+      ls = "ls --color";
+    };
+
+    oh-my-zsh = {
       enable = true;
-      autosuggestion.enable = true;
-
-      sessionVariables = {
-        GNUMAKEFLAGS = "-j12";
-        LESSHISTFILE = "-";
-      };
-
-      initContent = ''
-        vim() {
-          emacsclient -t "$@"
-        }
-      '';
-
-      oh-my-zsh = {
-        enable = true;
-        theme = "gentoo";
-        plugins = [
-          "sudo"
-          "git"
-          "vi-mode"
-          "git-auto-fetch"
-        ];
-      };
+      theme = "gentoo";
+      plugins = [
+        "sudo"
+        "git"
+        "vi-mode"
+        "git-auto-fetch"
+      ];
     };
   };
 }

--- a/features/home/doomemacs/doom/config.el
+++ b/features/home/doomemacs/doom/config.el
@@ -80,41 +80,46 @@
 ;;(set-frame-parameter (selected-frame) 'alpha '(95))
 ;;(add-to-list 'default-frame-alist '(alpha . (95)))
 
-(with-eval-after-load 'lsp-mode
+(after! lsp-mode
+  (setq lsp-diagnostics-provider :flycheck)
+
   (lsp-register-client
-    (make-lsp-client :new-connection (lsp-stdio-connection "nixd")
-                     :major-modes '(nix-mode)
-                     :priority 0
-                     :server-id 'nixd)))
+   (make-lsp-client
+    :new-connection (lsp-stdio-connection "nixd")
+    :major-modes '(nix-mode)
+    :priority 1
+    :server-id 'nixd)))
 
-(use-package nix-mode
-:after lsp-mode
-:ensure t
-:hook
-(nix-mode . lsp-deferred) ;; So that envrc mode will work
-:custom
-(lsp-disabled-clients '((nix-mode . nix-nil))) ;; Disable nil so that nixd will be used as lsp-server
-:config
-(setq lsp-nix-nixd-server-path "nixd"
-      lsp-nix-nixd-formatting-command [ "nixfmt" ]
-      lsp-nix-nixd-nixpkgs-expr "import <nixpkgs> { }"
+(after! flycheck
+  (flycheck-add-mode 'statix 'nix-mode))
 
-      ;; Use $NIXOS_CONFIG when available so Linux and macOS both work.
-      lsp-nix-nixd-nixos-options-expr
-      (let* ((repo (or (getenv "NIXOS_CONFIG")
-                       (expand-file-name "~/nixos-config")))
-             (flake (format "(builtins.getFlake \"%s\")" repo)))
-        (format "%s.nixosConfigurations.gibson.options" flake))
+(after! nix-mode
+  (add-hook 'nix-mode-hook #'lsp-deferred)
 
-      lsp-nix-nixd-home-manager-options-expr
-      (let* ((repo (or (getenv "NIXOS_CONFIG")
-                       (expand-file-name "~/nixos-config")))
-             (flake (format "(builtins.getFlake \"%s\")" repo)))
-        (format "%s.nixosConfigurations.gibson.config.home-manager.users.rickie.home.options" flake)))
+  (add-hook 'nix-mode-hook
+            (lambda ()
+              (add-to-list 'flycheck-disabled-checkers 'nix)
+              (setq-local company-idle-delay 0.1))))
 
-(add-hook! 'nix-mode-hook
-         ;; enable autocompletion with company
-         (setq company-idle-delay 0.1))
+(after! lsp-nix
+  (let* ((repo (or (getenv "NIXOS_CONFIG")
+                   (expand-file-name "~/nixos-config")))
+         (flake (format "(builtins.getFlake \"%s\")" repo))
+         (is-darwin (eq system-type 'darwin)))
+    (setq lsp-nix-nixd-server-path "nixd"
+          lsp-nix-nixd-formatting-command [ "nixfmt" ]
+          lsp-nix-nixd-nixpkgs-expr "import <nixpkgs> { }"
+          lsp-disabled-clients '((nix-mode . nix-nil))
+
+          lsp-nix-nixd-nixos-options-expr
+          (if is-darwin
+              (format "%s.darwinConfigurations.macbook.options" flake)
+            (format "%s.nixosConfigurations.gibson.options" flake))
+
+          lsp-nix-nixd-home-manager-options-expr
+          (if is-darwin
+              (format "%s.darwinConfigurations.macbook.config.home-manager.users.rickie.home.options" flake)
+            (format "%s.nixosConfigurations.gibson.config.home-manager.users.rickie.home.options" flake)))))
 
 (remove-hook 'markdown-mode-hook #'pretty-symbols-mode)
 (set-fontset-font t 'unicode "Noto Color Emoji" nil 'append)

--- a/features/home/doomemacs/doom/init.el
+++ b/features/home/doomemacs/doom/init.el
@@ -93,7 +93,7 @@
        (eval +overlay)     ; run code, run (also, repls)
        ;;gist              ; interacting with github gists
        lookup              ; navigate your code and its documentation
-       ;;lsp
+       lsp
        magit             ; a git porcelain for Emacs
        ;;make              ; run make tasks from Emacs
        ;;pass              ; password manager for nerds

--- a/features/home/gaming/module.nix
+++ b/features/home/gaming/module.nix
@@ -12,7 +12,11 @@
     };
   };
 
-  home.packages = [
+  home.packages = with pkgs; [
     inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.game-cleanup
+    (inputs.nixos-xivlauncher-rb.packages.${pkgs.stdenv.hostPlatform.system}.default.override {
+      useGameMode = true;
+    })
+    heroic
   ];
 }

--- a/features/home/kitty/module.nix
+++ b/features/home/kitty/module.nix
@@ -21,6 +21,10 @@
         confirm_os_window_close = 3;
         background_opacity = "0.7";
       };
+      extraConfig = ''
+        symbol_map U+e000-U+e00a,U+ea60-U+ebeb,U+e0a0-U+e0c8,U+e0ca,U+e0cc-U+e0d4,U+e200-U+e2a9,U+e300-U+e3e3,U+e5fa-U+e6b1,U+e700-U+e7c5,U+f000-U+f2e0,U+f300-U+f372,U+f400-U+f532,U+f0001-U+f1af0 Symbols Nerd Font Mono
+        symbol_map U+2600-U+26FF Noto Color Emoji
+      '';
     };
   };
 }

--- a/features/home/media/module.nix
+++ b/features/home/media/module.nix
@@ -5,6 +5,15 @@
   ...
 }:
 {
+  home.packages = with pkgs; [
+    jellyfin-desktop
+    jellyfin-mpv-shim
+    mpvpaper
+    pavucontrol
+    playerctl
+    vlc
+  ];
+
   programs = {
     imv.enable = true;
 

--- a/features/home/nix-settings/module.nix
+++ b/features/home/nix-settings/module.nix
@@ -5,8 +5,12 @@
   inputs,
   ...
 }:
+let
+  inherit (lib) optional;
+  inherit (pkgs.stdenv.hostPlatform) isLinux system;
+in
 {
-  nix = {
+  nix = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     gc = {
       automatic = true;
       options = "-d";
@@ -15,8 +19,10 @@
   };
 
   home.packages =
-    with lib;
-    mkIf pkgs.stdenv.hostPlatform.isLinux [
-      inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.nix-build-system
-    ];
+    optional isLinux inputs.self.packages.${system}.nix-build-system
+    ++ (with pkgs; [
+      nixfmt
+      nixd
+      statix
+    ]);
 }

--- a/features/home/obs-studio/module.nix
+++ b/features/home/obs-studio/module.nix
@@ -14,4 +14,8 @@
       obs-studio-plugins.obs-gstreamer
     ];
   };
+
+  home.packages = with pkgs; [
+    obs-cmd
+  ];
 }

--- a/flake/parts/features.nix
+++ b/flake/parts/features.nix
@@ -2,11 +2,7 @@
   imports = [
 
     # home-manager - core modules
-    ./../../features/home/core/base.nix
-    ./../../features/home/core/git.nix
-    ./../../features/home/core/gpg.nix
-    ./../../features/home/core/zoxide.nix
-    ./../../features/home/core/zsh.nix
+    ./../../features/home/core
 
     # home-manager - main modules
     ./../../features/home/doomemacs

--- a/hosts/gibson/home.nix
+++ b/hosts/gibson/home.nix
@@ -24,44 +24,20 @@
     };
 
     packages = with pkgs; [
-      act
-      bat
       bitwarden-desktop
-      bottles
       discord
       dracula-theme
       fontconfig
-      glib
       grimblast
-      heroic
       hyprpolkitagent
-      (inputs.nixos-xivlauncher-rb.packages.${stdenv.hostPlatform.system}.default.override {
-        useGameMode = true;
-      })
-      jellyfin-desktop
-      jellyfin-mpv-shim
       jq
       keyutils
-      krita
       libnotify
-      mpvpaper
-      nixfmt
-      nixd
       fastfetch
-      obs-cmd
-      pavucontrol
-      playerctl
-      protonup-qt
-      pwvucontrol
-      restic
       rivalcfg
       rofi-rbw-wayland
       signal-desktop
-      sops
       spice-gtk
-      vlc
-      vulkan-tools
-      webcord
       wl-clipboard
       wtype
     ];
@@ -75,8 +51,6 @@
       '';
 
       shellAliases = {
-        ls = "ls --color";
-        ll = "ls -lash";
         build-nix = "nix-build -E 'with import <nixpkgs> {}; callPackage ./default.nix {}'";
         cpu_usage = "ps -eo pid,ppid,%mem,%cpu,cmd --sort=-%cpu | head";
         mem_usage = "ps -eo pid,ppid,%mem,%cpu,cmd --sort=-%mem | head";
@@ -84,7 +58,6 @@
         nixos-rebuild = "systemd-inhibit --no-pager --no-legend --mode=block --who='${vars.username}' --why='NixOS Upgrades' sudo nixos-rebuild $@ --option eval-cache false --show-trace";
         spicy = "spicy --spice-ca-file=/etc/pki/libvirt-spice/ca-cert.pem --uri 'spice://127.0.0.1' -p 5900 -s 5901 --title 'th3h4x0r' -f > /dev/null 2>&1 &|";
         pass = "pass -c main";
-        less = "bat $@";
       };
 
       history.path = "${config.xdg.dataHome}/zsh/zsh_history";

--- a/hosts/macbook/home.nix
+++ b/hosts/macbook/home.nix
@@ -22,7 +22,6 @@
   programs = {
     zsh = {
       shellAliases = {
-        ll = "ls -lah";
         nixos-rebuild = "sudo darwin-rebuild switch --flake .#macbook";
       };
     };

--- a/hosts/macbook/system.nix
+++ b/hosts/macbook/system.nix
@@ -42,10 +42,21 @@
         "--fg-daemon"
       ];
       EnvironmentVariables = {
-        TERMINFO_DIRS =
-          "/Applications/Ghostty.app/Contents/Resources/terminfo:"
-          + "${pkgs.ncurses.out}/share/terminfo:"
-          + "/usr/share/terminfo:/etc/terminfo";
+        PATH = lib.concatStringsSep ":" [
+          "/etc/profiles/per-user/${vars.username}/bin"
+          "/run/current-system/sw/bin"
+          "/nix/var/nix/profiles/default/bin"
+          "/usr/bin"
+          "/bin"
+          "/usr/sbin"
+          "/sbin"
+        ];
+        TERMINFO_DIRS = lib.concatStringsSep ":" [
+          "${pkgs.ghostty-bin.terminfo}/share/terminfo"
+          "${pkgs.ncurses.out}/share/terminfo"
+          "/usr/share/terminfo"
+          "/etc/terminfo"
+        ];
       };
 
       RunAtLoad = true;

--- a/profiles/home/darwin.nix
+++ b/profiles/home/darwin.nix
@@ -5,6 +5,7 @@
     inputs.self.modules.homeManager.doomemacs
     inputs.self.modules.homeManager.ghostty
     inputs.self.modules.homeManager.qutebrowser
+    inputs.self.modules.homeManager.nix-settings
     inputs.self.modules.homeManager.sops-nix
     inputs.self.modules.homeManager.symlinks
     inputs.self.modules.homeManager.syncthing


### PR DESCRIPTION
This reworks a load of things:

Packages Rework:
- Adds in a default.nix file to expose all modules in features/home/core
- Updates features/home/core imports to be standard home-manager module files
- Relocates a number of gibson-specific home packages to relevant features/home/* modules
- Removes a few packages that basically aren't in use on gibson
- Adds some system-agnostic shell alias to the features/home/core/zsh module
- Adds bat as a system-agnostic package to features/home/core/base module

Emacs LSP:
- Makes nixd, nixfmt and statix system-agnostic
- Enables LSP in doomemacs config
- Updates the PATH env var used by emacs-daemon on darwin
- Improves the logic in dooms config.el for flycheck + LSP
- Fixes icon mapping for emacs TTY mode in kitty