### PR TITLE
flake(parts): dead code cleanup

### DIFF
--- a/flake/lib/mk-vars.nix
+++ b/flake/lib/mk-vars.nix
@@ -3,8 +3,8 @@
     {
       inputs,
       username,
-      hostname,
       system,
+      ...
     }:
     let
       isDarwin = builtins.match ".*-darwin" system != null;
@@ -18,8 +18,8 @@
     {
       inherit username;
       flakeSource = inputs.self;
-      secretsPath = builtins.toString inputs.nix-secrets;
+      secretsPath = toString inputs.nix-secrets;
       syncthingPath = "${homePrefix}/${username}/Sync";
-      age.keyFile = "${ageKeyFile}";
+      age.keyFile = ageKeyFile;
     };
 }

--- a/flake/parts/hosts/registry.nix
+++ b/flake/parts/hosts/registry.nix
@@ -71,7 +71,7 @@ in
   };
 
   config = {
-    _module.args.repoLib = rec {
+    _module.args.repoLib = {
       pkgsFor = system: {
         pkgs-stable = import inputs.nixpkgs-stable {
           inherit system;


### PR DESCRIPTION
next minor pass, cleaning up code; for flake-parts config, this:

- removes unused inputs
- removes any unused/unnecessary code
- cleans up any uncessary interpolation