### PR TITLE
hosts(gibson): enable VRR + rm kernel pin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -458,22 +458,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-qutebrowser-fix": {
-      "locked": {
-        "lastModified": 1774476476,
-        "narHash": "sha256-wwnVrY2pc5U/nZFEZpRQ634q+gQ3aPr3bIbeou8M9kk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4ceb3f35581a8ed908a21284105617d32ac59505",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4ceb3f35581a8ed908a21284105617d32ac59505",
-        "type": "github"
-      }
-    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1776434932,
@@ -665,7 +649,6 @@
         "nixpkgs": "nixpkgs_7",
         "nixpkgs-darwin": "nixpkgs-darwin",
         "nixpkgs-old": "nixpkgs-old",
-        "nixpkgs-qutebrowser-fix": "nixpkgs-qutebrowser-fix",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "qute-dracula": "qute-dracula",
         "sops-nix": "sops-nix",

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,6 @@
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-old.url = "github:nixos/nixpkgs/nixos-25.05";
     nixpkgs-darwin.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    nixpkgs-qutebrowser-fix.url = "github:NixOS/nixpkgs/4ceb3f35581a8ed908a21284105617d32ac59505";
 
     # nix-darwin / mac related
     nix-darwin.url = "github:LnL7/nix-darwin";

--- a/hosts/gibson/applications/hypr/hyprland.conf
+++ b/hosts/gibson/applications/hypr/hyprland.conf
@@ -15,7 +15,7 @@
         env = ELECTRON_OZONE_PLATFORM_HINT,auto
 
         # Monitor configuration
-        monitor = desc:BNQ BenQ EX2780Q 66L07726019,2560x1440@144,1920x0,1.25, vrr, 2, cm, hdr, sdrbrightness, 1.25, sdrsaturation, 1.0, bitdepth, 10
+        monitor = desc:BNQ BenQ EX2780Q 66L07726019,2560x1440@144,1920x0,1.25, vrr, 1, cm, hdr, sdrbrightness, 1.25, sdrsaturation, 1.0, bitdepth, 10
         monitor = desc:Ancor Communications Inc VG248 G6LMQS045879,1920x1080@144,0x200,1, bitdepth, 10
         monitor = desc:BNQ BenQ GL2460 F1D09565SL0,1920x1080@60,3968x160,1, bitdepth, 10 # Position = 1920 + 2560 / 1.25
 

--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -11,20 +11,13 @@
   vars,
   ...
 }:
-let
-  qutebrowser-fix = import inputs.nixpkgs-qutebrowser-fix {
-    inherit (pkgs.stdenv.hostPlatform) system;
-    config.allowUnfree = true;
-  };
-in
 {
   imports = [
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
   boot = {
-    #kernelPackages = pkgs.linuxPackages_zen;
-    kernelPackages = qutebrowser-fix.linuxPackages_zen;
+    kernelPackages = pkgs.linuxPackages_zen;
     kernelModules = [
       "nvidia"
       "nvidia_modeset"

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -146,10 +146,11 @@ in
       NVD_BACKEND = "direct";
       LIBVA_DRIVER_NAME = "nvidia";
       WLR_NO_HARDWARE_CURSORS = "1";
+      QTWEBENGINE_FORCE_USE_GBM = "0";
       __GLX_VENDOR_LIBRARY_NAME = "nvidia";
       __GL_MaxFramesAllowed = "1";
       __GL_GSYNC_ALLOWED = "1";
-      __GL_VRR_ALLOWED = "0";
+      __GL_VRR_ALLOWED = "1";
     };
 
     pathsToLink = [


### PR DESCRIPTION
- VRR was turned off for reasons I cant remember now...
- removed the qutebrowser-fix flake input
- switched back to bleeding edge zen kernel
- added a GBM specific env var to fix qutebrowser borking