### PR TITLE
hosts(gibson): nvidia driver bump + lutris fix

### DIFF
--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -5,7 +5,6 @@
   config,
   lib,
   pkgs,
-  inputs,
   modulesPath,
   system,
   vars,
@@ -120,7 +119,20 @@
       open = true;
       powerManagement.enable = true;
       nvidiaSettings = true;
-      package = config.boot.kernelPackages.nvidiaPackages.stable;
+      #package = config.boot.kernelPackages.nvidiaPackages.stable;
+
+      # TODO(upstream): remove once NixOS/nixpkgs#514481 reaches nixos-unstable
+      # https://nixpk.gs/pr-tracker.html?pr=514481
+      # Context: NVIDIA driver bump to fix an issue with qtwebengine applications rendering
+      package = config.boot.kernelPackages.nvidiaPackages.mkDriver {
+        version = "595.71.05";
+
+        sha256_64bit = "sha256-NiA7iWC35JyKQva6H1hjzeNKBek9KyS3mK8G3YRva4I=";
+        sha256_aarch64 = "sha256-XzKloS00dFKTd4ATWkTIhm9eG/OzR/Sim6MboNZWPu8=";
+        openSha256 = "sha256-Lfz71QWKM6x/jD2B22SWpUi7/og30HRlXg1kL3EWzEw=";
+        settingsSha256 = "sha256-mXnf3jyvznfB3OfKd657rxv0rYHQb/dX/Riw/+N9EKU=";
+        persistencedSha256 = "sha256-Z/6IvEEa/XfZ5F5qoSIPvXJLGtscYVqjFxHZaN/M2Ts=";
+      };
     };
   };
 

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -1,4 +1,9 @@
-_: {
+{
+  pkgs,
+  ...
+}:
+
+{
   nixpkgs.overlays = [
     (final: prev: {
       steam = prev.steam.override {
@@ -25,6 +30,33 @@ _: {
 
       mpv = prev.mpv.override {
         inherit (final) mpv-unwrapped;
+      };
+
+      # TODO(upstream): remove once upstream has a fix
+      # https://github.com/NixOS/nixpkgs/issues/513245
+      # Context: Prevents build test failures in OpenLDAP as required by Lutris
+      lutris = prev.lutris.override {
+        # Intercept buildFHSEnv to modify target packages
+        buildFHSEnv =
+          args:
+          pkgs.buildFHSEnv (
+            args
+            // {
+              multiPkgs =
+                envPkgs:
+                let
+                  # Fetch original package list
+                  originalPkgs = args.multiPkgs envPkgs;
+
+                  # Disable tests for openldap
+                  customLdap = envPkgs.openldap.overrideAttrs (_: {
+                    doCheck = false;
+                  });
+                in
+                # Replace broken openldap with the custom one
+                builtins.filter (p: (p.pname or "") != "openldap") originalPkgs ++ [ customLdap ];
+            }
+          );
       };
     })
   ];

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -146,7 +146,7 @@ in
       NVD_BACKEND = "direct";
       LIBVA_DRIVER_NAME = "nvidia";
       WLR_NO_HARDWARE_CURSORS = "1";
-      QTWEBENGINE_FORCE_USE_GBM = "0";
+      QTWEBENGINE_FORCE_USE_GBM = "1";
       __GLX_VENDOR_LIBRARY_NAME = "nvidia";
       __GL_MaxFramesAllowed = "1";
       __GL_GSYNC_ALLOWED = "1";


### PR DESCRIPTION
This bumps nvidia drivers from 595.58.03 -> 595.71.05 using an overlay.

It also disables openLDAP tests from lutris via overlay as this was breaking rebuilds.

As a small aside I've forced GBM to true, using an env var, within qtwebengine as the newer nvidia driver resolves problems with rendering in qtwebengine apps.

Overlays are commented to a relevant issue and/or PR.