### PR TITLE
features(home): add github-cli module

### DIFF
--- a/features/home/github-cli/default.nix
+++ b/features/home/github-cli/default.nix
@@ -1,0 +1,3 @@
+_: {
+  flake.modules.homeManager.github-cli = ./module.nix;
+}

--- a/features/home/github-cli/module.nix
+++ b/features/home/github-cli/module.nix
@@ -1,0 +1,8 @@
+_: {
+  programs.gh = {
+    enable = true;
+    settings = {
+      git_protocol = "ssh";
+    };
+  };
+}

--- a/flake/parts/features.nix
+++ b/flake/parts/features.nix
@@ -9,6 +9,7 @@
     ./../../features/home/fuzzel
     ./../../features/home/gaming
     ./../../features/home/ghostty
+    ./../../features/home/github-cli
     ./../../features/home/gtk-dracula
     ./../../features/home/hypr
     ./../../features/home/kitty

--- a/profiles/home/desktop.nix
+++ b/profiles/home/desktop.nix
@@ -6,6 +6,7 @@
     inputs.self.modules.homeManager.doomemacs
     inputs.self.modules.homeManager.fuzzel
     inputs.self.modules.homeManager.gaming
+    inputs.self.modules.homeManager.github-cli
     inputs.self.modules.homeManager.gtk-dracula
     inputs.self.modules.homeManager.hypr
     inputs.self.modules.homeManager.kitty


### PR DESCRIPTION
As suggested this adds in a new home-manager module for github-cli, and
this included in the default desktop profile.
