### PR TITLE
features(container): add wireshark override

### DIFF
--- a/features/system/containers/pentesting/default.nix
+++ b/features/system/containers/pentesting/default.nix
@@ -121,6 +121,18 @@ in
 
         programs.wireshark.enable = true;
 
+        # TODO(upstream): remove once upstream has a fix
+        # https://github.com/NixOS/nixpkgs/issues/515778
+        # https://nixpk.gs/pr-tracker.html?pr=515269
+        # Context: Prevents wireshark from building due to an incorrect hash
+        programs.wireshark.package = pkgs.wireshark-cli.overrideAttrs (oldAttrs: {
+          src = pkgs.fetchFromGitLab {
+            owner = "wireshark";
+            repo = "wireshark";
+            tag = "${oldAttrs.version}";
+            hash = "sha256-Zvrwxjp4LK2J3QnxmPxKKrU01YHQvPyp54UWzeGNCjA=";
+          };
+        });
         environment.systemPackages = with pkgs; [
           bashInteractive
           coreutils
@@ -153,7 +165,6 @@ in
           burpsuite
           firefox
           remmina
-          wireshark
         ];
 
         networking.firewall.enable = false;


### PR DESCRIPTION
This overrides the hash that the wireshark-cli pull uses as part of the wider wireshark pkg, included within the pentest container. The attached comment references the PR etc for tracking