### PR TITLE
flake(input): nix-secrets revision bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -331,11 +331,11 @@
     "nix-secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1776183120,
-        "narHash": "sha256-HdAInA76XB3xlUzyjqpxaaJf4qHiM7069FhcvJ0QXeU=",
+        "lastModified": 1777837878,
+        "narHash": "sha256-WtPeQN/A/lLd34fPK86gGkjjJyb+s2wuy05fZtfO35o=",
         "ref": "main",
-        "rev": "91a13c29676eefa83d03cf8b158d7371f72f0d6f",
-        "revCount": 21,
+        "rev": "66dfc29f2a6d126aaa1ad08db84d9d3e941a80f3",
+        "revCount": 22,
         "type": "git",
         "url": "ssh://git@github.com/5ysk3y/nix-secrets.git"
       },


### PR DESCRIPTION
This bumps my nix-secrets input to the latest revision in anticipation of an upcoming commit/PR improving reproducability for the new github-cli home-manager feature module.