### PR TITLE
module(home): sops - adds github-cli token

### DIFF
--- a/features/home/sops-nix/module.nix
+++ b/features/home/sops-nix/module.nix
@@ -31,6 +31,7 @@
 
       ## syncthing
       "services/syncthing/pass" = { };
+      "services/github-cli/token" = { };
 
       syncthing-cert = {
         format = "binary";


### PR DESCRIPTION
this adds a new secrets path within the sops home-manager module, named services/github-cli/token, that will be used in an upcoming commit to improve reproducability of the github-cli home-manager feature module.