### PR TITLE
feature(home): improve github-cli reproducability

### DIFF
--- a/features/home/github-cli/module.nix
+++ b/features/home/github-cli/module.nix
@@ -1,8 +1,38 @@
-_: {
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  tokenPath = config.sops.secrets."services/github-cli/token".path;
+
+  ghWrapped = pkgs.writeShellApplication {
+    name = "gh";
+    text = ''
+      if ! GH_TOKEN="$(cat ${lib.escapeShellArg tokenPath})"; then
+       echo "gh: failed to read GitHub token from ${lib.escapeShellArg tokenPath}" >&2
+         exit 1
+      fi
+
+      export GH_TOKEN
+      exec ${lib.getExe pkgs.gh} "$@"
+    '';
+  };
+in
+
+{
   programs.gh = {
     enable = true;
+    package = ghWrapped;
     settings = {
       git_protocol = "ssh";
+    };
+    hosts = {
+      "github.com" = {
+        user = "5ysk3y";
+      };
     };
   };
 }


### PR DESCRIPTION
This updates the home-manager feature module for github-cli to include a
wrapper for the nixpkgs supplied binary; this wrapper includes a valid
oAuth token, supplied via the sops-nix home-manager feature module,
exported into an env var that github-cli recognises keeping the secret
scope local to the application. This improves reproducability for the
module across all systems defined in conifg.
