### PR TITLE
profiles(home) - add github-cli to darwin

### DIFF
--- a/profiles/home/darwin.nix
+++ b/profiles/home/darwin.nix
@@ -4,6 +4,7 @@
     inputs.mac-app-util.homeManagerModules.default
     inputs.self.modules.homeManager.doomemacs
     inputs.self.modules.homeManager.ghostty
+    inputs.self.modules.homeManager.github-cli
     inputs.self.modules.homeManager.qutebrowser
     inputs.self.modules.homeManager.nix-settings
     inputs.self.modules.homeManager.sops-nix


### PR DESCRIPTION
Enables github-cli functionality on MacOS by default
