### PR TITLE
hosts(macbook): add syncthingtray/attic + qt fix

### DIFF
--- a/systems/darwin/macbook/home.nix
+++ b/systems/darwin/macbook/home.nix
@@ -12,7 +12,9 @@
     };
 
     packages = with pkgs; [
+      attic-client
       nixfmt
+      syncthingtray
     ];
   };
 

--- a/systems/darwin/macbook/overlays/default.nix
+++ b/systems/darwin/macbook/overlays/default.nix
@@ -1,6 +1,36 @@
 _: {
   nixpkgs.overlays = [
-    (_final: _prev: {
+    (final: prev: {
+      # Temporary qtwebengine Darwin build fix.
+      # Remove once upstream nixpkgs includes https://github.com/NixOS/nixpkgs/pull/515997
+      # Changes to these patches will require a rebuild.
+      qt6 = prev.qt6.overrideScope (
+        _qtFinal: qtPrev: {
+          qtwebengine = qtPrev.qtwebengine.overrideAttrs (old: {
+            patches =
+              (old.patches or [ ])
+              ++ final.lib.optionals final.stdenv.hostPlatform.isDarwin [
+                (final.fetchpatch {
+                  url = "https://raw.githubusercontent.com/NixOS/nixpkgs/2097933ced42bd2235a58b5483f38d738ca6d7b0/pkgs/development/libraries/qt-6/modules/qtwebengine/clang-base-path-from-cmake-compiler.patch";
+                  hash = "sha256-Z0vcxZeUlTv1YaWlxWT2r61pi1X8Q3kCTRoahNfa7Jc=";
+                })
+
+                (final.fetchpatch {
+                  url = "https://raw.githubusercontent.com/NixOS/nixpkgs/2097933ced42bd2235a58b5483f38d738ca6d7b0/pkgs/development/libraries/qt-6/modules/qtwebengine/lflags-remove-strip-darwin-isysroot.patch";
+                  hash = "sha256-ie3MJmDfJ2Af1ZtkOYGkUmBanUe/kqv1+uxIQmzzv6I=";
+                })
+              ];
+
+            cmakeFlags = map (
+              flag:
+              if final.stdenv.hostPlatform.isDarwin && flag == "-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0" then
+                "-DCMAKE_OSX_DEPLOYMENT_TARGET=12.0"
+              else
+                flag
+            ) (old.cmakeFlags or [ ]);
+          });
+        }
+      );
     })
   ];
 }


### PR DESCRIPTION
This PR adds in some upstream patches, yet to be merged, that appear to fix qtwebengine builds on darwin. These are large so ive configured a local attic cache to hold them for safety; builds do succeed though, now.