### PR TITLE
hosts(gibson): add fido2 to luks + tidy up

### DIFF
--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -54,11 +54,14 @@
         devices = {
           "rootfs" = {
             device = "/dev/disk/by-label/ROOT";
+            preLVM = true;
+            crypttabExtraOpts = [ "fido2-device=auto" ];
           };
           "swap" = {
             device = "/dev/disk/by-label/SWAP";
             preLVM = true;
             allowDiscards = true;
+            crypttabExtraOpts = [ "fido2-device=auto" ];
             keyFile = null;
           };
         };
@@ -119,23 +122,9 @@
       open = true;
       powerManagement.enable = true;
       nvidiaSettings = true;
-      #package = config.boot.kernelPackages.nvidiaPackages.stable;
-
-      # TODO(upstream): remove once NixOS/nixpkgs#514481 reaches nixos-unstable
-      # https://nixpk.gs/pr-tracker.html?pr=514481
-      # Context: NVIDIA driver bump to fix an issue with qtwebengine applications rendering
-      package = config.boot.kernelPackages.nvidiaPackages.mkDriver {
-        version = "595.71.05";
-
-        sha256_64bit = "sha256-NiA7iWC35JyKQva6H1hjzeNKBek9KyS3mK8G3YRva4I=";
-        sha256_aarch64 = "sha256-XzKloS00dFKTd4ATWkTIhm9eG/OzR/Sim6MboNZWPu8=";
-        openSha256 = "sha256-Lfz71QWKM6x/jD2B22SWpUi7/og30HRlXg1kL3EWzEw=";
-        settingsSha256 = "sha256-mXnf3jyvznfB3OfKd657rxv0rYHQb/dX/Riw/+N9EKU=";
-        persistencedSha256 = "sha256-Z/6IvEEa/XfZ5F5qoSIPvXJLGtscYVqjFxHZaN/M2Ts=";
-      };
+      package = config.boot.kernelPackages.nvidiaPackages.stable;
     };
   };
 
-  networking.useDHCP = lib.mkDefault true;
-  nixpkgs.hostPlatform = lib.mkDefault "${system}";
+  nixpkgs.hostPlatform = "${system}";
 }

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -33,7 +33,8 @@
       };
 
       # TODO(upstream): remove once upstream has a fix
-      # https://github.com/NixOS/nixpkgs/issues/513245
+      # https://github.com/NixOS/nixpkgs/issues/513245 - Build failure: lutris-free
+      # https://github.com/NixOS/nixpkgs/issues/514113 - pkgsi686Linux.openldap: test checks won't let it compile on x86_64
       # Context: Prevents build test failures in OpenLDAP as required by Lutris
       lutris = prev.lutris.override {
         # Intercept buildFHSEnv to modify target packages

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -18,25 +18,22 @@ in
   ];
 
   networking = {
-    hostName = "${hostname}";
+    useDHCP = false;
+    dhcpcd.enable = false;
+
+    hostName = hostname;
     timeServers = [ "192.168.1.1" ];
 
     networkmanager = {
       enable = true;
     };
 
-    bridges = {
-      "br0" = {
-        interfaces = [ "enp7s0" ];
-      };
-    };
-
-    interfaces.br0.useDHCP = true;
+    interfaces.enp7s0.useDHCP = false;
 
     nat = {
       enable = true;
       internalInterfaces = [ "ve-pentesting" ];
-      externalInterface = "br0";
+      externalInterface = "enp7s0";
     };
   };
 
@@ -406,6 +403,14 @@ in
     bluetooth = {
       enable = true;
       powerOnBoot = true;
+      settings = {
+        ConnectionParameters = {
+          MinInterval = 6;
+          MaxInterval = 9;
+          Latency = 44;
+          Timeout = 216;
+        };
+      };
     };
   };
 


### PR DESCRIPTION
- Adds fido2 to the list of unlock options for luks encrypted disks
- Removes the overlay for nvidia driver set; back to stable
- Added extra comment context to the existing lutris override
- Tidied up DHCP config location and disabled dhcpcd
- Removed the nic bridge, for now. I'll find a better way to do this
- Set some sane default config for bluetooth
