### PR TITLE
flake(input): pin qt stack for darwin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -638,6 +638,22 @@
         "type": "github"
       }
     },
+    "qtwebengine-fix": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      }
+    },
     "qute-dracula": {
       "flake": false,
       "locked": {
@@ -671,6 +687,7 @@
         "nixpkgs-darwin": "nixpkgs-darwin",
         "nixpkgs-old": "nixpkgs-old",
         "nixpkgs-stable": "nixpkgs-stable_2",
+        "qtwebengine-fix": "qtwebengine-fix",
         "qute-dracula": "qute-dracula",
         "sops-nix": "sops-nix",
         "wayland-pipewire-idle-inhibit": "wayland-pipewire-idle-inhibit"

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,8 @@
 
     qute-dracula.url = "github:dracula/qutebrowser";
     qute-dracula.flake = false;
+
+    qtwebengine-fix.url = "github:NixOS/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb";
   };
 
   outputs =

--- a/hosts/macbook/overlays/default.nix
+++ b/hosts/macbook/overlays/default.nix
@@ -1,12 +1,24 @@
-_: {
+{
+  inputs,
+  pkgs,
+  ...
+}:
+let
+  system = pkgs.stdenv.hostPlatform.system;
+  qtPinnedPkgs = import inputs.qtwebengine-fix {
+    inherit system;
+    config.allowUnfree = true;
+  };
+in
+{
   nixpkgs.overlays = [
     (final: prev: {
       # Temporary qtwebengine Darwin build fix.
       # Remove once upstream nixpkgs includes https://github.com/NixOS/nixpkgs/pull/515997
       # Changes to these patches will require a rebuild.
-      qt6 = prev.qt6.overrideScope (
+      qt6 = qtPinnedPkgs.qt6.overrideScope (
         _qtFinal: qtPrev: {
-          qtwebengine = qtPrev.qtwebengine.overrideAttrs (old: {
+          qtwebengine = qtPinnedPkgs.qt6.qtwebengine.overrideAttrs (old: {
             patches =
               (old.patches or [ ])
               ++ final.lib.optionals final.stdenv.hostPlatform.isDarwin [


### PR DESCRIPTION
This pins the qt stack to the nixpkgs revision referenced in last weeks
flake.lock update (17/05/26), which ensures the attic cache version of
qtwebengine continues to be served. The relevant override for macbook
has been updated to ensure the new input is used.
