### PR TITLE
flake(input): bump nixpkgs-stable to 26.05

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,8 +4,8 @@
   inputs = {
     # nixpkgs repos
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
-    nixpkgs-old.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-26.05";
+    nixpkgs-old.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-darwin.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     # nix-darwin / mac related


### PR DESCRIPTION
This also bumbs nixpkgs-old input to 25.11, should that be needed. Unstable remains as usual.