### PR TITLE
refactor(flake): consolidate nixpkgs inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -438,22 +438,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-darwin": {
-      "locked": {
-        "lastModified": 1780030872,
-        "narHash": "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "e9a7635a57597d9754eccebdfc7045e6c8600e6b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1777168982,
@@ -496,22 +480,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-old": {
-      "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -738,8 +706,6 @@
         "nix-secrets": "nix-secrets",
         "nixos-xivlauncher-rb": "nixos-xivlauncher-rb",
         "nixpkgs": "nixpkgs_8",
-        "nixpkgs-darwin": "nixpkgs-darwin",
-        "nixpkgs-old": "nixpkgs-old",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "qtwebengine-fix": "qtwebengine-fix",
         "qute-dracula": "qute-dracula",

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,10 @@
 
   inputs = {
     # nixpkgs repos
+    # Primary: used for all NixOS and darwin builds
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Stable: used for selectively pinning packages that need stability
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-26.05";
-    nixpkgs-old.url = "github:nixos/nixpkgs/nixos-25.11";
-    nixpkgs-darwin.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     # nix-darwin / mac related
     nix-darwin.url = "github:LnL7/nix-darwin";
@@ -38,12 +38,22 @@
     nix-gaming.url = "github:fufexan/nix-gaming";
     claude-code-nix.url = "github:sadjow/claude-code-nix";
 
+    # Used as a Nix store path in features/home/doomemacs/module.nix for the
+    # rsync-based activation script. The input hash drives the stamp-based
+    # doom sync-skip logic — keeping as a flake input is intentional.
     doomemacs.url = "github:doomemacs/doomemacs";
     doomemacs.flake = false;
 
+    # Used as a store path in features/home/symlinks/module.nix to symlink the
+    # Dracula theme into ~/.qutebrowser and ~/.config/qutebrowser. Keeping as a
+    # flake input so the path is in the Nix store and hash-pinned.
     qute-dracula.url = "github:dracula/qutebrowser";
     qute-dracula.flake = false;
 
+    # Temporary: pins a specific nixpkgs commit to fix qtwebengine on Darwin.
+    # Used only in hosts/macbook/overlays/default.nix.
+    # TODO: remove once https://github.com/NixOS/nixpkgs/pull/515997 lands in
+    # nixos-unstable and the macbook overlay is updated accordingly.
     qtwebengine-fix.url = "github:NixOS/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb";
   };
 

--- a/flake/parts/hosts/registry.nix
+++ b/flake/parts/hosts/registry.nix
@@ -72,18 +72,11 @@ in
 
   config = {
     _module.args.repoLib = {
+      # pkgsFor provides supplementary package sets passed as specialArgs.
+      # pkgs-stable: for packages that need pinning against the stable channel.
+      # Add further sets here if a new supplementary channel input is introduced.
       pkgsFor = system: {
         pkgs-stable = import inputs.nixpkgs-stable {
-          inherit system;
-          config.allowUnfree = true;
-        };
-
-        pkgs-old = import inputs.nixpkgs-old {
-          inherit system;
-          config.allowUnfree = true;
-        };
-
-        pkgs-darwin = import inputs.nixpkgs-darwin {
           inherit system;
           config.allowUnfree = true;
         };
@@ -114,6 +107,11 @@ in
 
               sharedModules = [
                 inputs.sops-nix.homeManagerModules.sops
+                # Primary nixpkgs is nixos-unstable; home-manager tracks master
+                # which matches unstable. The version mismatch warning fires as a
+                # false positive because pkgs-stable (26.05) is also in scope.
+                # Suppressing here rather than per-host since it applies globally.
+                { home.enableNixpkgsReleaseCheck = false; }
               ];
 
               users.${host.vars.username} = {

--- a/flake/parts/platforms/darwin.nix
+++ b/flake/parts/platforms/darwin.nix
@@ -9,16 +9,12 @@ let
 
   mkDarwinHost =
     host:
-    let
-      packages = repoLib.pkgsFor host.system;
-    in
     inputs.nix-darwin.lib.darwinSystem {
       inherit (host) system;
 
       specialArgs = {
         inherit inputs;
         inherit (host) hostname system vars;
-        inherit (packages) pkgs-darwin;
       };
 
       modules =

--- a/flake/parts/platforms/nixos.nix
+++ b/flake/parts/platforms/nixos.nix
@@ -18,7 +18,7 @@ let
       specialArgs = {
         inherit inputs;
         inherit (host) hostname system vars;
-        inherit (packages) pkgs-stable pkgs-old;
+        inherit (packages) pkgs-stable;
       };
 
       modules =
@@ -34,7 +34,7 @@ let
             backupFileExtension = "before-nix";
           };
           extraSpecialArgs = {
-            inherit (packages) pkgs-stable pkgs-old;
+            inherit (packages) pkgs-stable;
           };
         };
     };


### PR DESCRIPTION
- Remove unused nixpkgs-old and nixpkgs-darwin inputs; confirmed no
downstream consumers in features, profiles, or hosts.
- Drop instantiation of pkgs-old and pkgs-darwin from pkgsFor and remove
from all specialArgs propagation
- Add inline comments to doomemacs, qute-dracula, and qtwebengine-fix
explaining why they remain as flake inputs
