### PR TITLE
fix(home-manager): resolve useGlobalPkg warnings

### DIFF
--- a/features/home/claude-code/module.nix
+++ b/features/home/claude-code/module.nix
@@ -4,8 +4,9 @@
 }:
 
 {
-
-  nixpkgs.overlays = [ inputs.claude-code-nix.overlays.default ];
+  # Note: the claude-code-nix overlay is applied at the NixOS system level in
+  # hosts/gibson/overlays/default.nix — setting nixpkgs.overlays here has no
+  # effect when home-manager.useGlobalPkgs = true and will become an error.
   programs = {
     claude-code = {
       enable = true;

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -1,10 +1,15 @@
 {
+  inputs,
   pkgs,
   ...
 }:
 
 {
   nixpkgs.overlays = [
+    # claude-code-nix: must be applied at system level — nixpkgs.overlays set
+    # inside HM modules has no effect when useGlobalPkgs = true.
+    inputs.claude-code-nix.overlays.default
+
     (final: prev: {
       steam = prev.steam.override {
         extraPkgs =


### PR DESCRIPTION
- Move claude-code-nix overlay from HM module to system-level overlays —
nixpkgs.overlays set inside HM modules has no effect with useGlobalPkgs
= true and will cause an error in future HM releases.
