### PR TITLE
fix(githooks): pre-commit wipes staged hunks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Collect staged .nix files as NUL delimited
+# Stash unstaged changes so formatter only sees what's staged
+git stash --keep-index --include-untracked -q
+
 staged_nix_files=()
 while IFS= read -r -d '' f; do
   case "$f" in
@@ -19,3 +21,6 @@ fi
 
 echo "Statix"
 nix run nixpkgs#statix -- check .
+
+# Restore unstaged changes
+git stash pop -q || true


### PR DESCRIPTION
- Minor logic change in the pre-commit githook to ensure that if any
commits contain staged hunks, the pre-commit doesnt steamroller over
that by re-adding things that aren't desired.
