### PR TITLE
fix(gibson): pin nvidia 610.43.02 driver

### DIFF
--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -3,13 +3,24 @@
 # to /etc/nixos/configuration.nix instead.
 {
   config,
-  lib,
   pkgs,
   modulesPath,
   system,
   vars,
   ...
 }:
+let
+  nvidia610 =
+    config.boot.kernelPackages.nvidiaPackages.mkDriver {
+      version = "610.43.02";
+
+      sha256_64bit = "sha256-MDSgVLtM33dS/43CclZMsQVROAS/9TU4lFkBsWyndGM=";
+      sha256_aarch64 = "sha256-isWTnokUA/dzWocFBLalnk4+O5gSExVjs3dVpdYTU88=";
+      openSha256 = "sha256-hP5NVZZ4vGsACHLmUDKq4uckpd/kn1GxCSYnnJfAuBs=";
+      settingsSha256 = "sha256-0YAhufRgjDW+uR+kjaTb154fibpcDw8QowfrucoZsKE=";
+      persistencedSha256 = "sha256-Whgv9X+v2fRhzliOl2LzltY9v1SxDafFfv3IUPqj/hk=";
+    };
+in
 {
   imports = [
     (modulesPath + "/installer/scan/not-detected.nix")
@@ -122,7 +133,14 @@
       open = true;
       powerManagement.enable = true;
       nvidiaSettings = true;
-      package = config.boot.kernelPackages.nvidiaPackages.stable;
+      #package = config.boot.kernelPackages.nvidiaPackages.stable;
+      package = nvidia610.overrideAttrs (old: {
+        postInstall = (if old.postInstall or null == null then "" else old.postInstall) + ''
+    if [ -n "''${firmware:-}" ] && [ -d firmware ]; then
+      install -Dm644 -t "$firmware/lib/firmware/nvidia/$version" firmware/*.bin
+    fi
+  '';
+      });
     };
   };
 


### PR DESCRIPTION
- Pins nvidia driver to 610.43.02 via mkDriver.
- Pin nvidia-modprobe to the matching 610.43.02 tag via overlay to
keep versions in sync
- Override postInstall to install firmware blobs from the build
output.
