### PR TITLE
fix(ci): replace deprecated nixfmt with nix fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
       - uses: DeterminateSystems/determinate-nix-action@131015bad844610e5e6300f8a143bf625d3e74f4
       - uses: DeterminateSystems/flakehub-cache-action@c01e819d047464c3edf6ba778f075952af5a3aa7
 
-      - name: Nix format check (nixfmt)
+      - name: Nix format check (nix fmt)
         run: |
           set -euo pipefail
-          nix run nixpkgs#nixfmt -- .
+          nix fmt --no-write-lock-file
           git diff --exit-code || {
             echo ""
             echo "Formatting required."

--- a/flake/parts/outputs/formatter.nix
+++ b/flake/parts/outputs/formatter.nix
@@ -1,0 +1,8 @@
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      # Enables `nix fmt` to format all Nix files in the repo tree.
+      formatter = pkgs.nixfmt-tree;
+    };
+}


### PR DESCRIPTION
This is currently breaking CI checks.