### PR TITLE
chore(symlinks): use unqualified toString for qute-dracula path

### DIFF
--- a/features/home/symlinks/module.nix
+++ b/features/home/symlinks/module.nix
@@ -9,7 +9,7 @@
 let
   isLinux = pkgs != null && pkgs.stdenv.hostPlatform.isLinux;
   isDarwin = pkgs != null && pkgs.stdenv.hostPlatform.isDarwin;
-  draculaPath = builtins.toString inputs.qute-dracula.outPath;
+  draculaPath = toString inputs.qute-dracula.outPath;
 in
 {
   home.file = {


### PR DESCRIPTION
Replace builtins.toString with the unqualified toString — both are
equivalent in this context but the latter is idiomatic Nix style and
consistent with the rest of the codebase. It stops LSP from whinging
as well.
