### PR TITLE
fix(githooks): format staged content via index

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Stash unstaged changes so formatter only sees what's staged
-git stash --keep-index --include-untracked -q
-
+# Get list of staged .nix files
 staged_nix_files=()
 while IFS= read -r -d '' f; do
   case "$f" in
@@ -13,14 +11,25 @@ done < <(git diff --cached --name-only -z --diff-filter=ACMR)
 
 if (( ${#staged_nix_files[@]} > 0 )); then
   echo "Formatting staged Nix files"
-  nix run nixpkgs#nixfmt -- "${staged_nix_files[@]}"
-  git add -- "${staged_nix_files[@]}"
+
+  for f in "${staged_nix_files[@]}"; do
+    # 1. Extract the staged version of the file into a temp file
+    staged_tmp=$(mktemp /tmp/nixfmt-staged.XXXXXX.nix)
+    git show ":${f}" > "$staged_tmp"
+
+    # 2. Format the staged version in isolation
+    nix run nixpkgs#nixfmt -- "$staged_tmp"
+
+    # 3. Re-inject the formatted content back into the index only
+    #    This leaves the working tree (unstaged changes) untouched
+    new_blob=$(git hash-object -w "$staged_tmp")
+    git update-index --cacheinfo "100644,${new_blob},${f}"
+
+    rm -f "$staged_tmp"
+  done
 else
   echo "No staged Nix files to format"
 fi
 
 echo "Statix"
 nix run nixpkgs#statix -- check .
-
-# Restore unstaged changes
-git stash pop -q || true


### PR DESCRIPTION
Previously the hook used `git stash --keep-index` to isolate staged
changes before formatting, then `git stash pop` to restore unstaged
work. This was unreliable — the pop frequently caused merge conflicts
when the same file had both staged and unstaged changes, resulting in
conflict markers being injected into working tree files and uncommitted
changes being lost.

Rewritten to operate directly on the Git index instead of the working
tree. For each staged .nix file, the staged version is extracted via
`git show :<file>` into a temp file, formatted with nixfmt in
isolation, then re-injected into the index via `git hash-object` and
`git update-index --cacheinfo`. The working tree is never touched,
so unstaged changes are fully preserved regardless of overlap.

Also fixes a nixfmt deprecation warning by ensuring temp files are
given a .nix extension.
