### PR TITLE
fix(doomemacs): fix malformed defun and set git commit summary length

### DIFF
--- a/features/home/doomemacs/doom/config.el
+++ b/features/home/doomemacs/doom/config.el
@@ -136,9 +136,13 @@
 
 ;; improve colours for magit; makes them more like github darkmode
 (defun change-magit-diff-faces ()
-(set-face-attribute 'magit-section-highlight nil :background "#1b2330")
-(set-face-attribute 'magit-diff-hunk-heading nil :foreground "#9fb1c1" :background "#1f2a38")
-(set-face-attribute 'magit-diff-hunk-heading-highlight nil :foreground "#dce6f0" :background "#263445")
-(set-face-attribute 'magit-diff-context-highlight nil :background "#1b2330")
+    (set-face-attribute 'magit-section-highlight nil :background "#1b2330")
+    (set-face-attribute 'magit-diff-hunk-heading nil :foreground "#9fb1c1" :background "#1f2a38")
+    (set-face-attribute 'magit-diff-hunk-heading-highlight nil :foreground "#dce6f0" :background "#263445")
+    (set-face-attribute 'magit-diff-context-highlight nil :background "#1b2330"))
+
 (add-hook 'magit-mode-hook #'change-magit-diff-faces)
 (add-hook 'doom-load-theme-hook #'change-magit-diff-faces)
+ 
+;; increase character limit for max summary length
+(setq git-commit-summary-max-length 72)


### PR DESCRIPTION
- The `change-magit-diff-faces` defun was missing its closing parenthesis,
which has now been resolved
- Also adds `(setq git-commit-summary-max-length 72)` to relax Magit's
default 50 character summary line limit to the more widely accepted
72 character convention.
