### PR TITLE
feat(doom): configure remote development via TRAMP

### DIFF
--- a/features/home/doomemacs/doom/config.el
+++ b/features/home/doomemacs/doom/config.el
@@ -146,3 +146,24 @@
  
 ;; increase character limit for max summary length
 (setq git-commit-summary-max-length 72)
+
+;; TRAMP Stuffs
+(setq tramp-default-method "ssh")          ; faster than the default scp
+(setq remote-file-name-inhibit-cache nil)  ; cache aggressively
+(setq tramp-completion-reread-directory-timeout nil)
+
+(defun my/open-control-node ()
+  (interactive)
+  (find-file "/ssh:ansiblePrime.home.arpa:/home/ansible/ansible"))
+
+(map! :leader
+      :desc "Control node files" "o a" #'my/open-control-node)
+
+(after! vterm
+  (defun my/control-node-vterm ()
+    (interactive)
+    (let ((default-directory "/ssh:ansiblePrime.home.arpa:/home/ansible/ansible"))
+      (vterm "*ansible-prime*")))
+
+  (map! :leader
+        :desc "Control node terminal" "o t" #'my/control-node-vterm))

--- a/features/home/doomemacs/doom/init.el
+++ b/features/home/doomemacs/doom/init.el
@@ -76,7 +76,7 @@
        ;;eshell            ; the elisp shell that works everywhere
        ;;shell             ; simple shell REPL for Emacs
        ;;term              ; basic terminal emulator for Emacs
-       ;;vterm             ; the best terminal emulation in Emacs
+       vterm             ; the best terminal emulation in Emacs
 
        :checkers
        syntax              ; tasing you for every semicolon you forget
@@ -84,7 +84,7 @@
        ;;grammar           ; tasing grammar mistake every you make
 
        :tools
-       ;;ansible
+       ansible
        ;;debugger          ; FIXME stepping through code, to help you add bugs
        ;;direnv
        ;;docker
@@ -142,7 +142,7 @@
        ;;latex             ; writing papers in Emacs has never been so fun
        ;;lean              ; for folks with too much to prove
        ;;ledger            ; be audit you can be
-       ;;lua               ; one-based indices? one-based indices
+       lua               ; one-based indices? one-based indices
        markdown          ; writing docs for people to ignore
        ;;nim               ; python + lisp at the speed of c
        nix               ; I hereby declare "nix geht mehr!"
@@ -167,7 +167,7 @@
        ;;swift             ; who asked for emoji variables?
        ;;terra             ; Earth and Moon in alignment for performance.
        ;;web               ; the tubes
-       ;;yaml              ; JSON, but readable
+       yaml              ; JSON, but readable
        ;;zig               ; C, but simpler
 
        :email

--- a/features/home/doomemacs/doom/packages.el
+++ b/features/home/doomemacs/doom/packages.el
@@ -48,3 +48,5 @@
 ;(unpin! pinned-package another-pinned-package)
 ;; ...Or *all* packages (NOT RECOMMENDED; will likely break things)
 ;(unpin! t)
+
+(package! vterm :disable t)

--- a/features/home/doomemacs/module.nix
+++ b/features/home/doomemacs/module.nix
@@ -27,6 +27,7 @@ let
     (pkgs.emacsPackagesFor emacs).emacsWithPackages (epkgs: [
       epkgs.nix-mode
       epkgs.lsp-mode
+      epkgs.vterm
     ]);
 
   emacsPkg =


### PR DESCRIPTION
Adds Doom Emacs configuration to support a remote development workflow
against my Ansible control node, allowing files to be edited and
executed remotely without replicating dependencies locally:

- Enable `:term vterm` module for in-editor terminal support
- Add `epkgs.vterm` to Nix Emacs packages to avoid native compilation
issues on NixOS
- Configure TRAMP with SSH multiplexing for improved remote file
performance
- Add `my/open-control-node` shortcut (`SPC o a`) for quick dired access
to control node
- Add `my/control-node-vterm` shortcut (`SPC o t`) for a vterm session
on the control node
- Enabled ansible/lua/yaml tool/lang support
