### PR TITLE
chore(repo): add commit message template

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,11 @@
+# <type>(<scope>): <description>  [max 72 chars]
+# Valid types: feat fix refactor chore docs test revert
+# Scopes: e.g - gibson darwin sops yubikey bootstrap flake pkgs
+
+# Why: (motivation — what was wrong or needed)
+
+# What:
+# -
+# -
+
+# Notes: (caveats, follow-ups, nixos-specific gotchas)

--- a/features/home/core/git.nix
+++ b/features/home/core/git.nix
@@ -19,7 +19,10 @@ _: {
       };
 
       branch.autoSetupMerge = true;
-      commit.gpgsign = true;
+      commit = {
+        gpgsign = true;
+        template = ".gitmessage";
+      };
     };
 
     includes = [


### PR DESCRIPTION
In order to keep myself on top of consistent PR/commit title/body
convention I have added a .gitmessage file. If I leave it up to my brain
to remember it'll continue to be all over the place!

- Adds a .gitmessage file to the repo root
- Updates the home-manager git feature module to call this file as
commit.template in config.
