### PR TITLE
chore(repo): move commit-msg hook into hm module

### DIFF
--- a/features/home/core/git.nix
+++ b/features/home/core/git.nix
@@ -32,6 +32,10 @@ _: {
       }
     ];
 
+    hooks = {
+      commit-msg = ./git_hooks/commit-msg;
+    };
+
     signing.format = "openpgp";
   };
 }

--- a/features/home/core/git_hooks/commit-msg
+++ b/features/home/core/git_hooks/commit-msg
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+MSG=$(cat "$1")
+PATTERN='^(feat|fix|refactor|chore|docs|test|revert)(\([a-z0-9_-]+\))?: .{1,72}$'
+
+if ! echo "$MSG" | head -1 | grep -Pq "$PATTERN"; then
+  echo "✗ Commit title doesn't match convention:"
+  echo "  <type>(<scope>): <description>"
+  echo "  Example types: feat fix refactor repo chore docs test revert"
+  exit 1
+fi


### PR DESCRIPTION
Having realised that git hooks aren't tracked in git itself I've moved
a new commit-msg hook into the home-manager feature module for
reproducability.

This hook ensures that I stick to a consistent title pattern
by preventing commit completion if a an expected type isnt present.

- Adds programs.git.hooks into features/home/core/git.nix
- Adds the hook file itself at features/home/core/git_hooks/commit-msg
