### PR TITLE
fix(bitwarden): permit electron_39 to fix builds

### DIFF
--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -75,6 +75,13 @@
           hash = "sha256-4FzxZR85mWvqUh3FNNlzsg1b7yeMCXuVHMII4AeP8RA=";
         };
       });
+
+      # upstream nixpkgs issue - remove when bitwarden-desktop bumps electron
+      # TODO: Monitor this for upstream: https://github.com/NixOS/nixpkgs/issues/526914
+      # Also remove permittedInsecurePackages from hosts/gibson/system.nix
+      bitwarden-desktop = prev.bitwarden-desktop.override {
+        electron_39 = final.electron_39-bin;
+      };
     })
 
     inputs.self.overlays.default

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -396,6 +396,9 @@ in
   };
 
   nixpkgs.config.allowUnfree = true;
+  # upstream nixpkgs issue - remove when bitwarden-desktop bumps electron
+  # TODO: Monitor this for upstream: https://github.com/NixOS/nixpkgs/issues/526914
+  nixpkgs.config.permittedInsecurePackages = [ "electron-39.8.10" ];
 
   hardware = {
     i2c.enable = true;


### PR DESCRIPTION
This is contributing towards breaking CI, due to the fact that bitwarden uses a, now outdated, version of electron. I'll review this periodically and remove as soon as nixpkgs receives a version bump