### PR TITLE
fix(doomeamcs): update deprecated IS-MAC predicate

### DIFF
--- a/features/home/doomemacs/doom/init.el
+++ b/features/home/doomemacs/doom/init.el
@@ -106,7 +106,7 @@
        ;;upload            ; map local to remote projects via ssh/ftp
 
        :os
-       (:if IS-MAC macos)  ; improve compatibility with macOS
+       (:if (featurep :system 'macos) macos) ; improve compatibility with macOS
        (tty +osc)               ; improve the terminal Emacs experience
 
        :lang


### PR DESCRIPTION
This affects all hosts using the doomemacs home feature module
preventing sync on rebuilds. A darwin-related conditional predicate in
init.el has been deprecated in favour of a new API call.

- Migrate from IS-MAC to featurep system API.
