### PR TITLE
fix(disko): set gibson /boot umask to 0077

### DIFF
--- a/hosts/gibson/disko.nix
+++ b/hosts/gibson/disko.nix
@@ -24,7 +24,7 @@
               type = "filesystem";
               format = "vfat";
               mountpoint = "/boot";
-              mountOptions = [ "umask=0700" ];
+              mountOptions = [ "umask=0077" ];
             };
           };
 


### PR DESCRIPTION
The umask for vfat works inverted so umask=0077 would give 0700.
Fixes warnings about global read/write on /boot for new nixos installs.

- Sets umask mountOptions for /boot from 0700 -> 0077
