### PR TITLE
chore(repo): code cleanup pass via deadnix

### DIFF
--- a/features/home/claude-code/module.nix
+++ b/features/home/claude-code/module.nix
@@ -1,7 +1,4 @@
-{
-  inputs,
-  ...
-}:
+_:
 
 {
   # Note: the claude-code-nix overlay is applied at the NixOS system level in

--- a/features/home/hypr/hyprland.nix
+++ b/features/home/hypr/hyprland.nix
@@ -1,10 +1,8 @@
 {
-  config,
   lib,
   pkgs,
   vars,
   hostname,
-  inputs,
   ...
 }:
 let

--- a/features/system/containers/pentesting/default.nix
+++ b/features/system/containers/pentesting/default.nix
@@ -49,7 +49,7 @@ in
 
         nixpkgs.config.allowUnfree = true;
         nixpkgs.overlays = [
-          (final: prev: {
+          (_final: _prev: {
           })
         ];
 

--- a/flake/parts/outputs/packages.nix
+++ b/flake/parts/outputs/packages.nix
@@ -11,7 +11,7 @@
       };
     };
 
-  flake.overlays.default = final: prev: {
+  flake.overlays.default = final: _prev: {
     xivlauncher-rb = final.callPackage ./../../../pkgs/nixos-xivlauncher-rb { };
   };
 }

--- a/hosts/macbook/overlays/default.nix
+++ b/hosts/macbook/overlays/default.nix
@@ -12,12 +12,12 @@ let
 in
 {
   nixpkgs.overlays = [
-    (final: prev: {
+    (final: _prev: {
       # Temporary qtwebengine Darwin build fix.
       # Remove once upstream nixpkgs includes https://github.com/NixOS/nixpkgs/pull/515997
       # Changes to these patches will require a rebuild.
       qt6 = qtPinnedPkgs.qt6.overrideScope (
-        _qtFinal: qtPrev: {
+        _qtFinal: _qtPrev: {
           qtwebengine = qtPinnedPkgs.qt6.qtwebengine.overrideAttrs (old: {
             patches =
               (old.patches or [ ])


### PR DESCRIPTION
Periodically I'll run a deadnix pass over the whole repo to keep me
sweet in terms of standard practice and unused inputs. This commit is
exactly that.
