### PR TITLE
fix(gibson): simplify LUKS unlock sequence

### DIFF
--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -55,7 +55,7 @@ in
       timeout = 0;
       systemd-boot = {
         enable = true;
-        configurationLimit = 5;
+        configurationLimit = 20;
       };
       efi.canTouchEfiVariables = true;
     };
@@ -65,16 +65,22 @@ in
           "rootfs" = {
             device = "/dev/disk/by-label/ROOT";
             preLVM = true;
-            crypttabExtraOpts = [ "fido2-device=auto" ];
+            crypttabExtraOpts = [
+              "fido2-device=auto"
+              "token-timeout=30"
+            ];
           };
           "swap" = {
             device = "/dev/disk/by-label/SWAP";
             preLVM = true;
             allowDiscards = true;
-            crypttabExtraOpts = [ "fido2-device=auto" ];
-            keyFile = null;
+            crypttabExtraOpts = [ "keyfile-timeout=10s" ];
+            keyFile = "/swap.key";
           };
         };
+      };
+      secrets = {
+        "/swap.key" = "/etc/secrets/swap.key";
       };
       systemd.enable = true;
       availableKernelModules = [


### PR DESCRIPTION
Up to now my main host, gibson, has required Yubikey presence on boot to
unlock the LUKS encrypted OS disk, with a passphrase being used as
fallback. This unlock applies to both the ROOFS and SWAP partitions
which sometimes results in the need for multiple inputs to complete
boot, or indefinite hangs if timeouts were reached.

This commit retains a single initial unlock point on ROOTFS but moves
SWAP to use a keyfile thats supplied on-disk, making the overall boot
flow far more seemless.

- Remove FIDO requirement on SWAP partition
- Add a keyfile to SWAP to allow unlocks once ROOTFS is unlocked.
