### PR TITLE
chore(waybar): increase TTL for mouse_battery

### DIFF
--- a/features/home/waybar/scripts/default.nix
+++ b/features/home/waybar/scripts/default.nix
@@ -35,7 +35,7 @@
       cache_dir="''${XDG_RUNTIME_DIR:-/tmp}/waybar-mouse-battery"
       cache_file="$cache_dir/status.json"
       lock_file="$cache_dir/lock"
-      cache_ttl=20
+      cache_ttl=8
 
       alt_for_pct() {
         local p="$1"


### PR DESCRIPTION
TL;DR - this increases the battery poll rate for the waybar script
`mouse_battery` from 20s to 8s, so changes to battery appear slightly
quicker.

- Change cache_ttl to 8 for mouse_battery in
features/home/waybar/scripts
