### PR TITLE
chore(doomemacs): fix magit commit title highlighting

### DIFF
--- a/features/home/doomemacs/doom/config.el
+++ b/features/home/doomemacs/doom/config.el
@@ -145,7 +145,9 @@
 (add-hook 'doom-load-theme-hook #'change-magit-diff-faces)
  
 ;; increase character limit for max summary length
-(setq git-commit-summary-max-length 72)
+(after! git-commit
+  (setq git-commit-summary-max-length 72
+        git-commit-fill-column 72))
 
 ;; TRAMP Stuffs
 (setq tramp-default-method "ssh")          ; faster than the default scp


### PR DESCRIPTION
Why: To allow magits commit title length higlighting to match the match
the commit title length that is set.

What:
- Wrap git-commit-summary-max-length and git-commit-fill-column in (after! git-commit ...)
- Add git-commit-fill-column 72 alongside the existing summary length setting
