### PR TITLE
feat(flake): expose pkgs-unstable and allowUnfree across platforms

### DIFF
--- a/flake/parts/hosts/registry.nix
+++ b/flake/parts/hosts/registry.nix
@@ -80,6 +80,10 @@ in
           inherit system;
           config.allowUnfree = true;
         };
+        pkgs-unstable = import inputs.nixpkgs-unstable {
+          inherit system;
+          config.allowUnfree = true;
+        };
       };
 
       filterHosts = kind: hosts: lib.filterAttrs (_: v: v.kind == kind) hosts;

--- a/flake/parts/platforms/darwin.nix
+++ b/flake/parts/platforms/darwin.nix
@@ -9,22 +9,30 @@ let
 
   mkDarwinHost =
     host:
+    let
+      packages = repoLib.pkgsFor host.system;
+    in
     inputs.nix-darwin.lib.darwinSystem {
       inherit (host) system;
 
       specialArgs = {
         inherit inputs;
         inherit (host) hostname system vars;
+        inherit (packages) pkgs-unstable;
       };
 
       modules =
         host.systemProfiles
         ++ host.modules
+        ++ [ { nixpkgs.config.allowUnfree = true; } ]
         ++ repoLib.mkHomeManagerModule {
           platformModule = inputs.home-manager.darwinModules.home-manager;
           inherit host;
           hmExtra = {
             backupFileExtension = "before-nix";
+          };
+          extraSpecialArgs = {
+            inherit (packages) pkgs-unstable;
           };
         };
     };

--- a/flake/parts/platforms/nixos.nix
+++ b/flake/parts/platforms/nixos.nix
@@ -24,6 +24,7 @@ let
       modules =
         host.systemProfiles
         ++ host.modules
+        ++ [ { nixpkgs.config.allowUnfree = true; } ]
         ++ [
           inputs.sops-nix.nixosModules.sops
         ]


### PR DESCRIPTION
Why: pkgs-unstable was not accessible in Darwin system or home-manager modules, and allowUnfree was not consistently set across platforms, requiring per-host workarounds.

What:
- Instantiate pkgs-unstable in the host registry and pass it via specialArgs to Darwin system and home-manager modules
- Add `nixpkgs.config.allowUnfree = true` as an inline module on both Darwin and NixOS platforms for consistency

Notes: NixOS already had pkgs-unstable wired elsewhere; this change only adds the allowUnfree module inline. Darwin required threading pkgs-unstable through both system-level and home-manager extraSpecialArgs.
