### PR TITLE
feat(darwin): enable claude-code home-manager module

### DIFF
--- a/profiles/home/darwin.nix
+++ b/profiles/home/darwin.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     inputs.mac-app-util.homeManagerModules.default
+    inputs.self.modules.homeManager.claude-code
     inputs.self.modules.homeManager.doomemacs
     inputs.self.modules.homeManager.ghostty
     inputs.self.modules.homeManager.github-cli


### PR DESCRIPTION
Why: To allow use of claude-code on darwin/macos.

What:
- Add inputs.self.modules.homeManager.claude-code to darwin imports
