### PR TITLE
refactor(flake): remove per-host pkgs-unstable instantiation

### DIFF
--- a/flake/parts/hosts/registry.nix
+++ b/flake/parts/hosts/registry.nix
@@ -80,10 +80,6 @@ in
           inherit system;
           config.allowUnfree = true;
         };
-        pkgs-unstable = import inputs.nixpkgs-unstable {
-          inherit system;
-          config.allowUnfree = true;
-        };
       };
 
       filterHosts = kind: hosts: lib.filterAttrs (_: v: v.kind == kind) hosts;

--- a/flake/parts/platforms/darwin.nix
+++ b/flake/parts/platforms/darwin.nix
@@ -18,7 +18,6 @@ let
       specialArgs = {
         inherit inputs;
         inherit (host) hostname system vars;
-        inherit (packages) pkgs-unstable;
       };
 
       modules =
@@ -30,9 +29,6 @@ let
           inherit host;
           hmExtra = {
             backupFileExtension = "before-nix";
-          };
-          extraSpecialArgs = {
-            inherit (packages) pkgs-unstable;
           };
         };
     };


### PR DESCRIPTION
Why: I misread by flake inputs slightly; pkgs-unstable was already exposed at the flake level (#190), making the per-host instantiation in registry.nix and its propagation via specialArgs/extraSpecialArgs redundant

What:
- Remove pkgs-unstable import block from hosts/registry.nix
- Drop pkgs-unstable from darwin specialArgs and hmExtra extraSpecialArgs
