### PR TITLE
refactor(gibson): simplify PAM u2fAuth configuration

### DIFF
--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -184,33 +184,10 @@ in
       };
 
       services = {
-        login = {
-          u2fAuth = true;
-        };
-
-        sudo = {
-          u2fAuth = true;
-        };
-
-        sddm = {
-          text = ''
-            auth     sufficient    pam_u2f.so
-            auth     include       login
-            account  include       login
-            password include       login
-            session  include       login
-          '';
-        };
-
-        hyprlock = {
-          text = ''
-            auth     sufficient    pam_u2f.so
-            auth     include       login
-            account  include       login
-            password include       login
-            session  include       login
-          '';
-        };
+        login.u2fAuth = true;
+        sudo.u2fAuth = true;
+        sddm.u2fAuth = true;
+        hyprlock.u2fAuth = true;
       };
     };
   };


### PR DESCRIPTION
Why: PAM service blocks for sddm and hyprlock were manually specifying raw PAM text that duplicates what the u2fAuth option already generates, adding unnecessary verbosity and maintenance burden.

What:
- Replace manual PAM text blocks for sddm and hyprlock with u2fAuth = true
- Align sddm and hyprlock with the same pattern already used for login and sudo
