### PR TITLE
fix(hypr): update hypridle DPMS commands to new hyprctl dispatch API

### DIFF
--- a/features/home/hypr/hypridle.nix
+++ b/features/home/hypr/hypridle.nix
@@ -9,12 +9,12 @@
     with lib;
     mkIf pkgs.stdenv.hostPlatform.isLinux {
       services = {
-        hypridle = with pkgs; {
+        hypridle = {
           enable = true;
           settings = {
             general = {
               lock_cmd = "pidof hyprlock || hyprlock";
-              after_sleep_cmd = "hyprctl --batch 'dispatch exec makoctl mode -s default; dispatch exec sleep 1; dispatch dpms on'; wtype -k escape; openrgb -p ${config.xdg.configHome}/OpenRGB/MainBlue.orp;";
+              after_sleep_cmd = "hyprctl dispatch 'hl.dsp.dpms({ action = \"enable\" })'; wtype -k escape; openrgb -p ${config.xdg.configHome}/OpenRGB/MainBlue.orp;";
               on_unlock_cmd = "wtype -k escape";
             };
 
@@ -29,8 +29,8 @@
               }
               {
                 timeout = 600;
-                on-timeout = "sleep 1 && hyprctl dispatch dpms off";
-                on-resume = "sleep 1 && hyprctl --batch 'dispatch dpms on'";
+                on-timeout = "sleep 1 && hyprctl dispatch 'hl.dsp.dpms({ action = \"disable\" })'";
+                on-resume = "sleep 1 && hyprctl dispatch 'hl.dsp.dpms({ action = \"enable\" })'";
               }
               {
                 timeout = 900;


### PR DESCRIPTION
Why: Old `hyprctl dispatch dpms on/off` syntax is deprecated/removed in newer Hyprland; commands were no-ops or erroring at runtime.

What:
- Replace `dispatch dpms on/off` with `hl.dsp.dpms({ action = "enable/disable" })` across after_sleep_cmd, on-timeout, and on-resume
- Remove redundant `with pkgs;` binding from hypridle block
