### PR TITLE
feat(gibson): pin waybar to patched upstream commit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -689,6 +689,7 @@
         "qtwebengine-fix": "qtwebengine-fix",
         "qute-dracula": "qute-dracula",
         "sops-nix": "sops-nix",
+        "waybar-patched": "waybar-patched",
         "wayland-pipewire-idle-inhibit": "wayland-pipewire-idle-inhibit"
       }
     },
@@ -824,6 +825,23 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "waybar-patched": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777929458,
+        "narHash": "sha256-51R3mIt8cLNvh/X5qe9vOqeJCj0U9KRyemVE5y+OhiU=",
+        "owner": "Alexays",
+        "repo": "Waybar",
+        "rev": "05945748dccce28bf96d26d8f64a9e69a8dd49ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Alexays",
+        "ref": "0594574",
+        "repo": "Waybar",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,8 @@
     # TODO: remove once https://github.com/NixOS/nixpkgs/pull/515997 lands in
     # nixos-unstable and the macbook overlay is updated accordingly.
     qtwebengine-fix.url = "github:NixOS/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb";
+    waybar-patched.url = "github:Alexays/Waybar/0594574";
+    waybar-patched.flake = false;
   };
 
   outputs =

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -82,6 +82,17 @@
       bitwarden-desktop = prev.bitwarden-desktop.override {
         electron_39 = final.electron_39-bin;
       };
+
+      # TODO: Monitor new waybar package releases
+      # Associated PR is merged; requires a new release.
+      waybar = prev.waybar.overrideAttrs (old: {
+        src = inputs.waybar-patched;
+        version = "git-0594574";
+        mesonFlags = (builtins.filter (f: f != "-Dcava=enabled") (old.mesonFlags or [ ])) ++ [
+          "-Dcava=disabled"
+        ];
+        doInstallCheck = false;
+      });
     })
 
     inputs.self.overlays.default


### PR DESCRIPTION
Why: A merged upstream fix hasn't landed in a nixpkgs Waybar release
yet; pinning directly to the source commit to get the fix now. This
fixes a bug with hyprland workspace switching due to the migration to
LUA based API calls.

What:
- Add non-flake `waybar-patched` input
- Override `waybar` in gibson overlays to build from patched source, with cava disabled and install checks skipped

Notes: cava must be explicitly disabled (`-Dcava=disabled`) for this commit as the upstream build breaks with it enabled at this rev; overlay and input should be removed once the associated PR ships in a new Waybar release and nixpkgs picks it up.
