### PR TITLE
fix(gaming): wrap heroic to drop ambient CAP_SYS_NICE before bwrap

### DIFF
--- a/features/home/gaming/module.nix
+++ b/features/home/gaming/module.nix
@@ -11,11 +11,25 @@
     };
   };
 
-  home.packages = with pkgs; [
+  home.packages = [
     inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.game-cleanup
     (pkgs.xivlauncher-rb.override {
       useGameMode = true;
     })
-    heroic
+    # Wrap heroic to clear ambient CAP_SYS_NICE inherited from Hyprland's
+    # security wrapper before invoking the bwrap FHS env, which refuses to
+    # run when ambient caps are set without setuid.
+    # Upstream: nixpkgs#526193 / nixpkgs#217119
+    (pkgs.symlinkJoin {
+      name = "heroic";
+      paths = [
+        (pkgs.writeShellScriptBin "heroic" ''
+          exec ${pkgs.perl}/bin/perl \
+            -e 'syscall(157,47,4,0,0,0); exec @ARGV' \
+            -- ${pkgs.heroic}/bin/heroic "$@"
+        '')
+        pkgs.heroic # to include icons/desktop file
+      ];
+    })
   ];
 }


### PR DESCRIPTION
Why: Hyprland's security wrapper sets ambient CAP_SYS_NICE on launched processes; bwrap refuses to construct the FHS environment when ambient capabilities are present without setuid, causing Heroic to fail to launch.

What:
- Replace bare heroic package with a symlinkJoin wrapping the binary via a perl one-liner that calls prctl(PR_CAP_AMBIENT_CLEAR_ALL) before exec
- Retain pkgs.heroic in the join paths so icons and .desktop files remain available
