### PR TITLE
refactor(bootstrap): overhaul bootstrap with Darwin support, tests and disk fixes

### DIFF
--- a/bootstrap/common.sh
+++ b/bootstrap/common.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# bootstrap/common.sh
+# Sourced by install.sh and install-darwin.sh — never executed directly.
+#
+# Provides:
+#   die, usage_common, arg_defaults, parse_common_args,
+#   resolve_sudo, setup_gpg_smartcard, setup_known_hosts,
+#   check_yubikey_age, clone_or_update_repo, decrypt_age_blob
+#
+# Callers MUST export before sourcing:
+#   PLATFORM      "linux" | "darwin"
+#   SCRIPT_NAME   basename of the calling script (for usage strings)
+#
+# Callers inherit:
+#   YUBI_IDENT    path to temp file for the YubiKey identity descriptor
+#                 (written by decrypt_age_blob, cleaned up on EXIT)
+
+# ---------------------------------------------------------------------------
+# Guard: must be sourced, not executed
+# ---------------------------------------------------------------------------
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "ERROR: common.sh must be sourced, not executed directly." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Verify required caller-set variables
+# ---------------------------------------------------------------------------
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+[[ -n "${PLATFORM:-}"     ]] || die "PLATFORM must be exported before sourcing common.sh"
+[[ -n "${SCRIPT_NAME:-}"  ]] || die "SCRIPT_NAME must be set before sourcing common.sh"
+[[ "$PLATFORM" == "linux" || "$PLATFORM" == "darwin" ]] \
+  || die "PLATFORM must be 'linux' or 'darwin', got: $PLATFORM"
+
+# ---------------------------------------------------------------------------
+# Defaults — called by each install script before arg parsing
+# ---------------------------------------------------------------------------
+arg_defaults() {
+  NIXOS_CONFIG_ORIGIN="git@github.com:5ysk3y/nixos-config.git"
+  NIX_SECRETS_ORIGIN="git@github.com:5ysk3y/nix-secrets.git"
+  NIX_SECRETS_BRANCH="main"
+
+  # GPG public key URL — used to import the key on a fresh system so the
+  # YubiKey can be associated and SSH auth via gpg-agent can work.
+  GPG_KEY_URL="https://github.com/5ysk3y.gpg"
+
+  USER_NAME="rickie"
+  USER_UID="1000"
+  USER_GID="100"
+  DO_INSTALL=0
+  CONFIG_DEST=""
+  SECRETS_SUBDIR="secrets"
+  SECRETS_BLOB_REL="bootstrap/age-keys.txt.age"
+
+  if [[ "$PLATFORM" == "darwin" ]]; then
+    HOST="macbook"
+    TARGET="/"
+  else
+    HOST="gibson"
+    TARGET="/mnt"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Usage preamble — callers append platform-specific sections
+# ---------------------------------------------------------------------------
+usage_common() {
+  cat <<EOF
+Usage: bootstrap/${SCRIPT_NAME} [OPTIONS]
+
+Shared options:
+  --user NAME           Username (default: rickie)
+  --uid N               UID      (default: 1000)
+  --gid N               GID      (default: 100)
+  --host NAME           Flake host attribute to build
+  --dry-run             Clone + decrypt secrets, then stop (default)
+  --install             Also run the final install step
+  --config-dest PATH    Where to clone nixos-config
+  --secrets-subdir DIR  nix-secrets dir relative to config-dest (default: secrets)
+  --secrets-blob PATH   Encrypted age identity blob inside nix-secrets
+                        (default: bootstrap/age-keys.txt.age)
+  --help | -h           Show this help
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# Unknown flags accumulate in REMAINING_ARGS for the caller to handle or reject.
+# ---------------------------------------------------------------------------
+parse_common_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --user)           USER_NAME="$2";        shift 2 ;;
+      --uid)            USER_UID="$2";         shift 2 ;;
+      --gid)            USER_GID="$2";         shift 2 ;;
+      --host)           HOST="$2";             shift 2 ;;
+      --install)        DO_INSTALL=1;          shift   ;;
+      --dry-run)        DO_INSTALL=0;          shift   ;;
+      --config-dest)    CONFIG_DEST="$2";      shift 2 ;;
+      --secrets-subdir) SECRETS_SUBDIR="$2";   shift 2 ;;
+      --secrets-blob)   SECRETS_BLOB_REL="$2"; shift 2 ;;
+      --help|-h)        usage; exit 0 ;;
+      *)                REMAINING_ARGS+=("$1"); shift ;;
+    esac
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Sudo helper — resolved once, used everywhere
+# ---------------------------------------------------------------------------
+resolve_sudo() {
+  SUDO=""
+  if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+    command -v sudo >/dev/null 2>&1 \
+      || die "sudo is required when not running as root."
+    SUDO="sudo"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# GPG / smartcard setup
+#
+# Handles the full chain required on a fresh system:
+#
+#   1. scdaemon disable-ccid — prevents the CCID driver competing with pcscd
+#      for exclusive USB access to the YubiKey. Without this one daemon wins
+#      the device and the other fails silently.
+#
+#   2. gpg-agent SSH support — enables the agent to serve SSH keys from the
+#      YubiKey's OpenPGP auth slot and exports SSH_AUTH_SOCK so git can use it.
+#
+#   3. GPG public key import — fetches the public key from GitHub so gpg
+#      knows about the key and can associate it with the physical card.
+#      Required on a fresh system (e.g. NixOS live ISO) where the keyring is
+#      empty. Skipped if the key is already present.
+#
+#   4. pcscd restart — ensures the smartcard daemon is running and has a clean
+#      connection to the card. Linux only; macOS PCSC is launchd-managed.
+#
+#   5. gpg --card-status — wakes the YubiKey and forces gpg to associate the
+#      card with the imported public key. Required before SSH auth will work.
+#
+# On Darwin: pcscd is skipped; everything else applies.
+# ---------------------------------------------------------------------------
+setup_gpg_smartcard() {
+  local gnupg_home="${GNUPGHOME:-$HOME/.gnupg}"
+  mkdir -p "$gnupg_home"
+  chmod 700 "$gnupg_home"
+
+  # 1. scdaemon: disable-ccid
+  local scdaemon_conf="$gnupg_home/scdaemon.conf"
+  if ! grep -qx 'disable-ccid' "$scdaemon_conf" 2>/dev/null; then
+    echo "Configuring scdaemon: disable-ccid (prevents CCID/PCSC conflict)..."
+    echo "disable-ccid" >> "$scdaemon_conf"
+  fi
+
+  # 2. gpg-agent: enable SSH support
+  local agent_conf="$gnupg_home/gpg-agent.conf"
+  if ! grep -qx 'enable-ssh-support' "$agent_conf" 2>/dev/null; then
+    echo "Enabling gpg-agent SSH support..."
+    echo "enable-ssh-support" >> "$agent_conf"
+  fi
+
+  # Restart agent so config changes take effect
+  echo "Restarting gpg-agent / scdaemon..."
+  gpgconf --kill scdaemon  >/dev/null 2>&1 || true
+  gpgconf --kill gpg-agent >/dev/null 2>&1 || true
+
+  # 3. pcscd (Linux only)
+  if [[ "$PLATFORM" == "linux" ]]; then
+    if command -v systemctl >/dev/null 2>&1 && systemctl is-system-running --quiet 2>/dev/null; then
+      $SUDO systemctl restart pcscd >/dev/null 2>&1 || true
+    else
+      # Non-systemd or systemd not yet running (e.g. NixOS live ISO)
+      $SUDO pkill -x pcscd >/dev/null 2>&1 || true
+      sleep 1
+      $SUDO pcscd --foreground &>/dev/null &
+      sleep 1
+    fi
+  fi
+  # Darwin: com.apple.ifdreader is launchd-managed; killing scdaemon is sufficient.
+
+  # 4. Export SSH_AUTH_SOCK so git can use the YubiKey for SSH auth.
+  #    gpgconf --list-dirs agent-ssh-socket gives the correct path regardless
+  #    of whether the agent was just started or was already running.
+  local ssh_sock
+  ssh_sock="$(gpgconf --list-dirs agent-ssh-socket 2>/dev/null || true)"
+  if [[ -n "$ssh_sock" ]]; then
+    export SSH_AUTH_SOCK="$ssh_sock"
+  fi
+
+  # 5. Import GPG public key if not already in keyring.
+  #    gpg --list-keys exits non-zero if the key is absent.
+  echo "Checking GPG keyring..."
+  if ! gpg --list-keys "$GPG_KEY_URL" >/dev/null 2>&1; then
+    echo "Importing GPG public key from ${GPG_KEY_URL}..."
+    gpg --fetch-keys "$GPG_KEY_URL" \
+      || die "Failed to fetch GPG public key from ${GPG_KEY_URL} — is the network up?"
+  fi
+
+  # 6. Wake the YubiKey and associate the card with the imported key.
+  echo "Waking YubiKey smartcard..."
+  gpg --card-status >/dev/null 2>&1 \
+    || die "YubiKey not detected — is it plugged in? (gpg --card-status)"
+}
+
+# ---------------------------------------------------------------------------
+# SSH known_hosts — ensure github.com is present before any git operations
+# ---------------------------------------------------------------------------
+setup_known_hosts() {
+  local ssh_dir="${HOME}/.ssh"
+  local known_hosts="${ssh_dir}/known_hosts"
+
+  mkdir -p "$ssh_dir"
+  chmod 700 "$ssh_dir"
+  touch "$known_hosts"
+  chmod 600 "$known_hosts"
+
+  if ! ssh-keygen -F github.com -f "$known_hosts" >/dev/null 2>&1; then
+    echo "Adding github.com to known_hosts..."
+    ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> "$known_hosts" \
+      || die "ssh-keyscan github.com failed — is the network up?"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# YubiKey age identity probe
+# Fails fast with a clear message if no YubiKey age slot is visible.
+# ---------------------------------------------------------------------------
+check_yubikey_age() {
+  echo "Checking YubiKey age identities..."
+  local recip
+  recip="$(age-plugin-yubikey --list 2>/dev/null | grep . | tail -n1 || true)"
+  [[ -n "$recip" ]] \
+    || die "No YubiKey age recipients found — is the key inserted? (age-plugin-yubikey --list)"
+  echo "Found YubiKey recipient: $recip"
+}
+
+# ---------------------------------------------------------------------------
+# Clone or update a git repository
+#
+#   clone_or_update_repo LABEL ORIGIN DEST [BRANCH]
+#
+# Without BRANCH (nixos-config): fetch + fast-forward only. Local commits are
+# preserved; divergence is reported but not fatal.
+#
+# With BRANCH (nix-secrets): fetch + hard-reset to origin/BRANCH. This repo
+# is treated as read-only canonical state — no local modifications expected.
+# ---------------------------------------------------------------------------
+clone_or_update_repo() {
+  local label="$1" origin="$2" dest="$3" branch="${4:-}"
+
+  if [[ -d "$dest/.git" ]]; then
+    echo "${label}: already cloned at ${dest}, updating..."
+    git -C "$dest" fetch --all --prune
+
+    if [[ -n "$branch" ]]; then
+      git -C "$dest" checkout "$branch"
+      git -C "$dest" reset --hard "origin/$branch"
+    else
+      local current_branch
+      current_branch="$(git -C "$dest" branch --show-current 2>/dev/null || true)"
+      if [[ -n "$current_branch" ]]; then
+        git -C "$dest" merge --ff-only "origin/$current_branch" 2>/dev/null \
+          || echo "  (fast-forward skipped — local commits present or branch diverged)"
+      fi
+    fi
+  else
+    echo "${label}: cloning into ${dest}..."
+    mkdir -p "$(dirname "$dest")"
+    rm -rf "$dest"
+    if [[ -n "$branch" ]]; then
+      git clone --branch "$branch" "$origin" "$dest"
+    else
+      git clone "$origin" "$dest"
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Decrypt the YubiKey-encrypted age identity blob
+#
+#   decrypt_age_blob BLOB_PATH KEYS_DIR KEYS_FILE IS_ROOT_OWNED
+#
+# IS_ROOT_OWNED: "true"  = chown root:root + sudo (Linux /var/lib/age)
+#                "false" = user-owned, no sudo  (Darwin ~/Library/...)
+# ---------------------------------------------------------------------------
+decrypt_age_blob() {
+  local blob="$1" keys_dir="$2" keys_file="$3" root_owned="${4:-false}"
+
+  [[ -f "$blob" ]] || die "Missing secrets blob: ${blob}"
+
+  echo "Generating YubiKey identity descriptor..."
+  age-plugin-yubikey --identity > "$YUBI_IDENT"
+
+  echo "Decrypting age identity blob — touch your YubiKey when prompted..."
+
+  if [[ "$root_owned" == "true" ]]; then
+    $SUDO install -d -m 0700 "$keys_dir"
+    $SUDO age -d -i "$YUBI_IDENT" -o "$keys_file" "$blob"
+    $SUDO chmod 0600 "$keys_file"
+    $SUDO chown root:root "$keys_file"
+  else
+    mkdir -p "$keys_dir"
+    chmod 0700 "$keys_dir"
+    age -d -i "$YUBI_IDENT" -o "$keys_file" "$blob"
+    chmod 0600 "$keys_file"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Shared temp directory — provides $YUBI_IDENT to decrypt_age_blob
+# Cleaned up on EXIT of the sourcing script.
+# ---------------------------------------------------------------------------
+_BS_TMPDIR="$(mktemp -d)"
+YUBI_IDENT="$_BS_TMPDIR/yubikey-identity.txt"
+
+_bs_cleanup() { rm -rf "$_BS_TMPDIR"; }
+trap _bs_cleanup EXIT

--- a/bootstrap/common.sh
+++ b/bootstrap/common.sh
@@ -50,7 +50,7 @@ arg_defaults() {
   USER_GID="100"
   DO_INSTALL=0
   CONFIG_DEST=""
-  SECRETS_SUBDIR="secrets"
+  SECRETS_SUBDIR="nix-secrets"
   SECRETS_BLOB_REL="bootstrap/age-keys.txt.age"
 
   if [[ "$PLATFORM" == "darwin" ]]; then
@@ -59,6 +59,7 @@ arg_defaults() {
   else
     HOST="gibson"
     TARGET="/mnt"
+    DISK=""
   fi
 }
 
@@ -77,9 +78,10 @@ Shared options:
   --dry-run             Clone + decrypt secrets, then stop (default)
   --install             Also run the final install step
   --config-dest PATH    Where to clone nixos-config
-  --secrets-subdir DIR  nix-secrets dir relative to config-dest (default: secrets)
+  --secrets-subdir DIR  nix-secrets sibling dir name (default: nix-secrets)
   --secrets-blob PATH   Encrypted age identity blob inside nix-secrets
                         (default: bootstrap/age-keys.txt.age)
+  --disk DEVICE         Target disk device for disko (e.g. /dev/sda)
   --help | -h           Show this help
 EOF
 }
@@ -100,6 +102,7 @@ parse_common_args() {
       --config-dest)    CONFIG_DEST="$2";      shift 2 ;;
       --secrets-subdir) SECRETS_SUBDIR="$2";   shift 2 ;;
       --secrets-blob)   SECRETS_BLOB_REL="$2"; shift 2 ;;
+      --disk)           DISK="$2";             shift 2 ;;
       --help|-h)        usage; exit 0 ;;
       *)                REMAINING_ARGS+=("$1"); shift ;;
     esac
@@ -121,77 +124,86 @@ resolve_sudo() {
 # ---------------------------------------------------------------------------
 # GPG / smartcard setup
 #
-# Handles the full chain required on a fresh system:
+# Order matters:
+#   1. Write scdaemon/gpg-agent config BEFORE starting any daemons
+#   2. Start pcscd FIRST so it claims the card via CCID
+#   3. Kill and restart gpg-agent AFTER pcscd is running so scdaemon
+#      starts with disable-ccid already set and yields to pcscd
+#   4. Import GPG public key so gpg can associate the card
+#   5. Wake card with gpg --card-status
+#   6. Force agent to learn card slots via gpg-connect-agent
+#   7. Export SSH_AUTH_SOCK after agent has fully loaded the card
 #
-#   1. scdaemon disable-ccid — prevents the CCID driver competing with pcscd
-#      for exclusive USB access to the YubiKey. Without this one daemon wins
-#      the device and the other fails silently.
-#
-#   2. gpg-agent SSH support — enables the agent to serve SSH keys from the
-#      YubiKey's OpenPGP auth slot and exports SSH_AUTH_SOCK so git can use it.
-#
-#   3. GPG public key import — fetches the public key from GitHub so gpg
-#      knows about the key and can associate it with the physical card.
-#      Required on a fresh system (e.g. NixOS live ISO) where the keyring is
-#      empty. Skipped if the key is already present.
-#
-#   4. pcscd restart — ensures the smartcard daemon is running and has a clean
-#      connection to the card. Linux only; macOS PCSC is launchd-managed.
-#
-#   5. gpg --card-status — wakes the YubiKey and forces gpg to associate the
-#      card with the imported public key. Required before SSH auth will work.
-#
-# On Darwin: pcscd is skipped; everything else applies.
+# On Darwin: pcscd is skipped; macOS PCSC (com.apple.ifdreader) is
+#            launchd-managed and always present.
 # ---------------------------------------------------------------------------
 setup_gpg_smartcard() {
   local gnupg_home="${GNUPGHOME:-$HOME/.gnupg}"
   mkdir -p "$gnupg_home"
   chmod 700 "$gnupg_home"
 
-  # 1. scdaemon: disable-ccid
+  export GPG_TTY=$(tty)
+
+  # 1. Write config files before any daemon starts so they take effect
+  #    on first start rather than requiring a restart.
   local scdaemon_conf="$gnupg_home/scdaemon.conf"
   if ! grep -qx 'disable-ccid' "$scdaemon_conf" 2>/dev/null; then
-    echo "Configuring scdaemon: disable-ccid (prevents CCID/PCSC conflict)..."
+    echo "Configuring scdaemon: disable-ccid (yields card access to pcscd)..."
     echo "disable-ccid" >> "$scdaemon_conf"
   fi
 
-  # 2. gpg-agent: enable SSH support
   local agent_conf="$gnupg_home/gpg-agent.conf"
   if ! grep -qx 'enable-ssh-support' "$agent_conf" 2>/dev/null; then
     echo "Enabling gpg-agent SSH support..."
     echo "enable-ssh-support" >> "$agent_conf"
   fi
 
-  # Restart agent so config changes take effect
+  if ! grep -q 'pinentry-program' "$agent_conf" 2>/dev/null; then
+    echo "pinentry-program $(command -v pinentry-curses)" >> "$agent_conf"
+  fi
+
+  # 2. Start pcscd first (Linux only) so it claims the card via CCID
+  #    before scdaemon starts. On a NixOS live ISO we need to symlink
+  #    the ccid bundle into pcscd's compiled-in driver directory first.
+  if [[ "$PLATFORM" == "linux" ]]; then
+    if command -v systemctl >/dev/null 2>&1 && systemctl is-system-running --quiet 2>/dev/null; then
+      if ! $SUDO systemctl restart pcscd >/dev/null 2>&1; then
+        # pcscd not available as a systemd service (e.g. NixOS live ISO)
+        $SUDO pkill -x pcscd >/dev/null 2>&1 || true
+        sleep 1
+        local ccid_bundle
+        ccid_bundle="$(find /nix/store -maxdepth 4 -name 'ifd-ccid.bundle' 2>/dev/null | head -1 || true)"
+        if [[ -n "$ccid_bundle" ]]; then
+          $SUDO mkdir -p /var/lib/pcsc/drivers
+          $SUDO ln -sf "$ccid_bundle" /var/lib/pcsc/drivers/
+        fi
+        $SUDO pcscd --foreground &>/dev/null &
+        sleep 3
+      fi
+    else
+      # Non-systemd / NixOS live ISO
+      $SUDO pkill -x pcscd >/dev/null 2>&1 || true
+      sleep 1
+      local ccid_bundle
+      ccid_bundle="$(find /nix/store -maxdepth 4 -name 'ifd-ccid.bundle' 2>/dev/null | head -1 || true)"
+      if [[ -n "$ccid_bundle" ]]; then
+        $SUDO mkdir -p /var/lib/pcsc/drivers
+        $SUDO ln -sf "$ccid_bundle" /var/lib/pcsc/drivers/
+      fi
+      $SUDO pcscd --foreground &>/dev/null &
+      sleep 3
+    fi
+  fi
+  # Darwin: com.apple.ifdreader is launchd-managed; no action needed.
+
+  # 3. Kill and restart gpg-agent / scdaemon AFTER pcscd is running.
+  #    scdaemon will now start with disable-ccid set and yield to pcscd.
   echo "Restarting gpg-agent / scdaemon..."
   gpgconf --kill scdaemon  >/dev/null 2>&1 || true
   gpgconf --kill gpg-agent >/dev/null 2>&1 || true
+  gpg-agent --daemon --enable-ssh-support >/dev/null 2>&1 || true
 
-  # 3. pcscd (Linux only)
-  if [[ "$PLATFORM" == "linux" ]]; then
-    if command -v systemctl >/dev/null 2>&1 && systemctl is-system-running --quiet 2>/dev/null; then
-      $SUDO systemctl restart pcscd >/dev/null 2>&1 || true
-    else
-      # Non-systemd or systemd not yet running (e.g. NixOS live ISO)
-      $SUDO pkill -x pcscd >/dev/null 2>&1 || true
-      sleep 1
-      $SUDO pcscd --foreground &>/dev/null &
-      sleep 1
-    fi
-  fi
-  # Darwin: com.apple.ifdreader is launchd-managed; killing scdaemon is sufficient.
-
-  # 4. Export SSH_AUTH_SOCK so git can use the YubiKey for SSH auth.
-  #    gpgconf --list-dirs agent-ssh-socket gives the correct path regardless
-  #    of whether the agent was just started or was already running.
-  local ssh_sock
-  ssh_sock="$(gpgconf --list-dirs agent-ssh-socket 2>/dev/null || true)"
-  if [[ -n "$ssh_sock" ]]; then
-    export SSH_AUTH_SOCK="$ssh_sock"
-  fi
-
-  # 5. Import GPG public key if not already in keyring.
-  #    gpg --list-keys exits non-zero if the key is absent.
+  # 4. Import GPG public key if not already in keyring.
   echo "Checking GPG keyring..."
   if ! gpg --list-keys "$GPG_KEY_URL" >/dev/null 2>&1; then
     echo "Importing GPG public key from ${GPG_KEY_URL}..."
@@ -199,10 +211,28 @@ setup_gpg_smartcard() {
       || die "Failed to fetch GPG public key from ${GPG_KEY_URL} — is the network up?"
   fi
 
-  # 6. Wake the YubiKey and associate the card with the imported key.
+  # 5. Wake the YubiKey and verify it is detected.
   echo "Waking YubiKey smartcard..."
   gpg --card-status >/dev/null 2>&1 \
     || die "YubiKey not detected — is it plugged in? (gpg --card-status)"
+
+  # 6. Force gpg-agent to learn the card's key slots so it can serve
+  #    SSH signing operations. Without this the agent sees the card but
+  #    refuses to sign ("agent refused operation").
+  echo "Loading card key slots into gpg-agent..."
+  gpg-connect-agent "scd serialno" "learn --force" /bye >/dev/null 2>&1 || true
+  echo "bootstrap-pin-cache" | gpg --sign --default-key 7D73BA8CF10F7F67 --output /tmp/bootstrap-pin-cache.gpg
+  rm -f /tmp/bootstrap-pin-cache.gpg
+
+  # 7. gpgconf --list-dirs agent-ssh-socket can return empty in nix shell environments.
+  # Construct the socket path directly — gpg-agent always uses this location.
+  local gpg_agent_sock="/run/user/$(id -u)/gnupg/S.gpg-agent.ssh"
+  if [[ -S "$gpg_agent_sock" ]]; then
+    export SSH_AUTH_SOCK="$gpg_agent_sock"
+  elif [[ -S "${GNUPGHOME:-$HOME/.gnupg}/S.gpg-agent.ssh" ]]; then
+    export SSH_AUTH_SOCK="${GNUPGHOME:-$HOME/.gnupg}/S.gpg-agent.ssh"
+  fi
+
 }
 
 # ---------------------------------------------------------------------------
@@ -250,6 +280,8 @@ check_yubikey_age() {
 # ---------------------------------------------------------------------------
 clone_or_update_repo() {
   local label="$1" origin="$2" dest="$3" branch="${4:-}"
+  local effective_sock="/run/user/$(id -u)/gnupg/S.gpg-agent.ssh"
+  export SSH_AUTH_SOCK="$effective_sock"
 
   if [[ -d "$dest/.git" ]]; then
     echo "${label}: already cloned at ${dest}, updating..."

--- a/bootstrap/install-darwin.sh
+++ b/bootstrap/install-darwin.sh
@@ -190,7 +190,7 @@ echo "=== Activating nix-darwin ==="
 [[ -f "$AGE_KEYS_FILE"    ]] || die "Age key missing: $AGE_KEYS_FILE"
 [[ -d "$CONFIG_DEST/.git" ]] || die "nixos-config clone missing: $CONFIG_DEST"
 
-if command -v darwin-rebuild >/dev/null 2>&1; then
+if darwin-rebuild --version >/dev/null 2>&1; then
   echo "Running darwin-rebuild switch..."
   darwin-rebuild switch --flake "$CONFIG_DEST#$HOST"
 else

--- a/bootstrap/install-darwin.sh
+++ b/bootstrap/install-darwin.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# bootstrap/install-darwin.sh — nix-darwin (macOS) bootstrap
+#
+# Bootstraps a fresh macOS install with nix-darwin:
+#   1. Installs Nix via the Determinate Systems installer if absent
+#   2. Re-execs under `nix shell` to get a pinned tool environment
+#   3. Configures GPG smartcard coexistence
+#   4. Clones nixos-config + nix-secrets via YubiKey SSH auth
+#   5. Decrypts the YubiKey-encrypted age identity blob
+#      → ~/Library/Application Support/sops/age/keys.txt
+#      (matches vars.age.keyFile for isDarwin in flake/lib/mk-vars.nix)
+#   6. Optionally activates the nix-darwin configuration
+#
+# Run as your normal user. sudo is used only where unavoidable.
+# YubiKey must be plugged in; you will be prompted to touch it once.
+#
+# For testing without the nix shell re-exec, set:
+#   _DARWIN_BOOTSTRAP_NIX_SHELL=1 bash bootstrap/install-darwin.sh ...
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Phase 1: pre-Nix setup and re-exec guard
+# ---------------------------------------------------------------------------
+if [[ "${_DARWIN_BOOTSTRAP_NIX_SHELL:-0}" != "1" ]]; then
+
+  # Minimum macOS version: nix-darwin requires Sonoma (14.0)+
+  _macos_ver="$(sw_vers -productVersion)"
+  _macos_major="${_macos_ver%%.*}"
+  if [[ "$_macos_major" -lt 14 ]]; then
+    echo "ERROR: macOS 14 (Sonoma) or later required. Found: $_macos_ver" >&2
+    exit 1
+  fi
+
+  # Install Nix if absent
+  if ! command -v nix >/dev/null 2>&1; then
+    echo "Nix not found — installing via Determinate Systems installer..."
+    # Idempotent, multi-user, works on Apple Silicon and Intel.
+    curl --proto '=https' --tlsv1.2 -sSf \
+      https://install.determinate.systems/nix | sh -s -- install --no-confirm
+    # Source the daemon profile so `nix` is on PATH immediately
+    # shellcheck disable=SC1091
+    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh || true
+    echo "Nix installed: $(nix --version)"
+  else
+    echo "Nix found: $(nix --version)"
+  fi
+
+  echo "Re-executing under nix shell for pinned tool environment..."
+  exec env _DARWIN_BOOTSTRAP_NIX_SHELL=1 \
+    nix shell \
+      nixpkgs#bashInteractive \
+      nixpkgs#coreutils \
+      nixpkgs#git \
+      nixpkgs#openssh \
+      nixpkgs#gnupg \
+      nixpkgs#age \
+      nixpkgs#age-plugin-yubikey \
+      --command bash -- "$0" "$@"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 2: running inside the nix shell tool environment
+# ---------------------------------------------------------------------------
+export PLATFORM="darwin"
+SCRIPT_NAME="install-darwin.sh"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+  usage_common
+  cat <<EOF
+
+Darwin notes:
+  TARGET is always / on macOS — there is no install-time mountpoint.
+
+  Age key path is fixed to match flake/lib/mk-vars.nix (isDarwin branch):
+    ~/Library/Application Support/sops/age/keys.txt
+
+Examples:
+  # Dry-run
+  bootstrap/install-darwin.sh --host macbook
+
+  # Full activation
+  bootstrap/install-darwin.sh --host macbook --install
+
+Notes:
+  - Run as your normal user, not root.
+  - YubiKey must be plugged in; you will be prompted to touch it.
+  - On a fresh Mac, Nix is installed automatically before proceeding.
+  - nix-darwin does not need to be pre-installed; the script handles
+    first-time activation via `nix run`.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+arg_defaults   # HOST=macbook, TARGET=/ for darwin
+
+REMAINING_ARGS=()
+parse_common_args "$@"
+
+[[ ${#REMAINING_ARGS[@]} -eq 0 ]] \
+  || die "Unknown argument(s): ${REMAINING_ARGS[*]}"
+
+# Darwin paths — TARGET is always /, no mount prefix
+[[ -n "$CONFIG_DEST" ]] || CONFIG_DEST="$HOME/nixos-config"
+
+# Age key path MUST match mk-vars.nix isDarwin branch:
+#   "${homePrefix}/${username}/Library/Application Support/sops/age/keys.txt"
+# This is user-owned; no sudo required.
+AGE_KEYS_DIR="$HOME/Library/Application Support/sops/age"
+AGE_KEYS_FILE="$AGE_KEYS_DIR/keys.txt"
+
+SECRETS_DEST="$(dirname "$CONFIG_DEST")/$SECRETS_SUBDIR"
+SECRETS_BLOB="$SECRETS_DEST/$SECRETS_BLOB_REL"
+
+MODE="dry-run"; [[ $DO_INSTALL -eq 1 ]] && MODE="install"
+
+resolve_sudo
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo "=== nix-darwin bootstrap (YubiKey-first) ==="
+echo "Repo root    : $ROOT_DIR"
+echo "User         : $USER_NAME"
+echo "Host         : $HOST"
+echo "Mode         : $MODE"
+echo "Config dest  : $CONFIG_DEST"
+echo "Secrets dest : $SECRETS_DEST"
+echo "Secrets blob : $SECRETS_BLOB_REL"
+echo "Age key file : $AGE_KEYS_FILE"
+echo
+
+# Advisory check for /run symlink (nix-darwin creates this on first activation)
+if [[ ! -L /run ]] && [[ ! -d /run ]]; then
+  echo "Note: /run does not exist yet — nix-darwin will create it on first activation."
+  echo "      A reboot or new shell session may be needed afterwards."
+  echo
+fi
+
+# ---------------------------------------------------------------------------
+# Bootstrap steps
+# ---------------------------------------------------------------------------
+mkdir -p "$(dirname "$CONFIG_DEST")"
+
+setup_gpg_smartcard
+setup_known_hosts
+check_yubikey_age
+
+clone_or_update_repo "nixos-config" "$NIXOS_CONFIG_ORIGIN" "$CONFIG_DEST"
+clone_or_update_repo "nix-secrets"  "$NIX_SECRETS_ORIGIN"  "$SECRETS_DEST" "$NIX_SECRETS_BRANCH"
+
+# root_owned=false: Darwin age key is user-owned under ~/Library
+decrypt_age_blob "$SECRETS_BLOB" "$AGE_KEYS_DIR" "$AGE_KEYS_FILE" "false"
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+echo
+echo "✅ Bootstrap complete."
+echo
+echo "  $CONFIG_DEST   → nixos-config"
+echo "  $SECRETS_DEST  → nix-secrets"
+echo "  $AGE_KEYS_FILE → sops-nix age keyFile"
+echo
+
+if [[ $DO_INSTALL -eq 0 ]]; then
+  echo "Dry-run — next steps:"
+  echo "  If nix-darwin has been activated before on this machine:"
+  echo "    darwin-rebuild switch --flake $CONFIG_DEST#$HOST"
+  echo
+  echo "  First-time activation:"
+  echo "    nix run nix-darwin#darwin-rebuild -- switch --flake $CONFIG_DEST#$HOST"
+  echo
+  echo "  After first activation, open a new shell for PATH changes to take effect."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Install mode — activate nix-darwin configuration
+# ---------------------------------------------------------------------------
+echo "=== Activating nix-darwin ==="
+[[ -f "$AGE_KEYS_FILE"    ]] || die "Age key missing: $AGE_KEYS_FILE"
+[[ -d "$CONFIG_DEST/.git" ]] || die "nixos-config clone missing: $CONFIG_DEST"
+
+if command -v darwin-rebuild >/dev/null 2>&1; then
+  echo "Running darwin-rebuild switch..."
+  darwin-rebuild switch --flake "$CONFIG_DEST#$HOST"
+else
+  echo "darwin-rebuild not in PATH — running first-time activation via nix run..."
+  # Current nix-darwin bootstrap command (LnL7/nix-darwin, post-flakes):
+  # https://github.com/LnL7/nix-darwin#flakes
+  nix run nix-darwin#darwin-rebuild -- switch --flake "$CONFIG_DEST#$HOST"
+fi
+
+echo
+echo "✅ nix-darwin activation completed."
+echo
+echo "Open a new terminal for PATH and shell integrations to take effect."

--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S nix shell nixpkgs#bashInteractive nixpkgs#coreutils nixpkgs#git nixpkgs#openssh nixpkgs#gnupg nixpkgs#pcsclite nixpkgs#age nixpkgs#age-plugin-yubikey --command bash
+#!/usr/bin/env -S nix shell nixpkgs#bashInteractive nixpkgs#coreutils nixpkgs#git nixpkgs#openssh nixpkgs#gnupg nixpkgs#pcsclite nixpkgs#ccid nixpkgs#pinentry-curses nixpkgs#age nixpkgs#age-plugin-yubikey --command bash
 # bootstrap/install.sh — NixOS (Linux) bootstrap
 #
 # Bootstraps a fresh NixOS install:
@@ -19,10 +19,13 @@ set -euo pipefail
 # Phase 1: ensure we are running inside the nix shell tool environment
 # The shebang handles this in normal use; the env var bypass is for tests.
 # ---------------------------------------------------------------------------
+export NIX_CONFIG="experimental-features = nix-command flakes"
+
 if [[ "${_NIXOS_BOOTSTRAP_NIX_SHELL:-0}" != "1" ]]; then
   # When invoked as `bash install.sh` the shebang is skipped but we still
   # need the tool environment. Re-exec under nix shell.
   exec env _NIXOS_BOOTSTRAP_NIX_SHELL=1 \
+    SSH_AUTH_SOCK="" \
     nix shell \
       nixpkgs#bashInteractive \
       nixpkgs#coreutils \
@@ -30,12 +33,14 @@ if [[ "${_NIXOS_BOOTSTRAP_NIX_SHELL:-0}" != "1" ]]; then
       nixpkgs#openssh \
       nixpkgs#gnupg \
       nixpkgs#pcsclite \
+      nixpkgs#ccid \
+      nixpkgs#pinentry-curses \
       nixpkgs#age \
       nixpkgs#age-plugin-yubikey \
       --command bash -- "$0" "$@"
 fi
-
 # ---------------------------------------------------------------------------
+#
 # Phase 2: running inside the tool environment
 # ---------------------------------------------------------------------------
 export PLATFORM="linux"
@@ -116,6 +121,9 @@ resolve_sudo
 echo "=== NixOS bootstrap (YubiKey-first) ==="
 echo "Repo root    : $ROOT_DIR"
 echo "Target       : $TARGET"
+if [[ -n "$DISK" ]]; then
+    echo "Target Disk  : $DISK"
+fi
 echo "User         : $USER_NAME ($USER_UID:$USER_GID)"
 echo "Host         : $HOST"
 echo "Mode         : $MODE"
@@ -127,20 +135,47 @@ echo
 
 [[ -d "$TARGET" ]] || die "Target path does not exist: $TARGET"
 
+DISKO_NIX="$ROOT_DIR/hosts/$HOST/disko.nix"
+if [[ $DO_INSTALL -eq 1 ]] && [[ -f "$DISKO_NIX" ]]; then
+    echo "=== Disko config found for $HOST: Running disko... ==="
+    DISKO_ARGS=("$DISKO_NIX")
+    [[ -n "$DISK" ]] && DISKO_ARGS+=(--argstr disk "$DISK")
+
+    echo -n "temporarypassword" | $SUDO tee /tmp/disko-luks-password > /dev/null
+
+    # Ensure that the drive doesnt have residual LUKS headers
+    sudo dd if=/dev/zero of="$DISK" bs=1M count=1100
+
+    sudo -E NIX_CONFIG="$NIX_CONFIG" nix run nixpkgs#disko -- \
+        --mode destroy,format,mount \
+        --argstr disk "$DISK" "$DISKO_NIX"
+    echo "=== Setting LUKS passphrases ==="
+    sudo cryptsetup luksChangeKey /dev/disk/by-partlabel/disk-main-ROOT \
+        --key-file /tmp/disko-luks-password
+    sudo cryptsetup luksChangeKey /dev/disk/by-partlabel/disk-main-SWAP \
+        --key-file /tmp/disko-luks-password
+    rm -f /tmp/disko-luks-password
+fi
+
 # ---------------------------------------------------------------------------
 # Prepare target directory tree
 # ---------------------------------------------------------------------------
 echo "Preparing target directories..."
 $SUDO mkdir -p "$TARGET/etc/nixos" "$USER_HOME" "$CONFIG_PARENT" \
-               "$TARGET/var/lib" "$AGE_KEYS_DIR"
+               "$TARGET/var/lib" "$AGE_KEYS_DIR" \
+               "$TARGET/tmp"
+$SUDO chmod 1777 "$TARGET/tmp"
 $SUDO chown "$USER_UID:$USER_GID" "$USER_HOME" 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
 # Bootstrap steps
 # ---------------------------------------------------------------------------
 setup_gpg_smartcard
+export SSH_AUTH_SOCK="/run/user/$(id -u)/gnupg/S.gpg-agent.ssh"
 setup_known_hosts
 check_yubikey_age
+
+export SSH_AUTH_SOCK="/run/user/$(id -u)/gnupg/S.gpg-agent.ssh"
 
 clone_or_update_repo "nixos-config" "$NIXOS_CONFIG_ORIGIN" "$CONFIG_DEST"
 clone_or_update_repo "nix-secrets"  "$NIX_SECRETS_ORIGIN"  "$SECRETS_DEST" "$NIX_SECRETS_BRANCH"
@@ -174,16 +209,23 @@ fi
 # ---------------------------------------------------------------------------
 echo "=== Running nixos-install ==="
 [[ -d "$TARGET/etc"      ]] || die "Target sanity check failed: $TARGET/etc missing"
-[[ -f "$AGE_KEYS_FILE"   ]] || die "Age key missing: $AGE_KEYS_FILE"
+$SUDO test -f "$AGE_KEYS_FILE" || die "Age key missing: $AGE_KEYS_FILE"
 [[ -d "$CONFIG_DEST/.git" ]] || die "nixos-config clone missing: $CONFIG_DEST"
 
 # Preserve SSH_AUTH_SOCK so flake SSH inputs (nix-secrets) resolve during install.
+$SUDO git config --system --add safe.directory "$CONFIG_DEST"
+$SUDO git config --system --add safe.directory "$SECRETS_DEST"
+# Pre-cache auth PIN in current TTY context so nixos-install can fetch
+# private flake inputs without needing to prompt for PIN under sudo.
+SSH_AUTH_SOCK="${SSH_AUTH_SOCK:-/run/user/$(id -u)/gnupg/S.gpg-agent.ssh}" \
+ssh -T -o StrictHostKeyChecking=no git@github.com 2>/dev/null || true
 $SUDO env -i \
-  HOME="$HOME" \
-  USER="${USER:-$USER_NAME}" \
+  HOME="/root" \
+  USER="root" \
   PATH="$PATH" \
   SSH_AUTH_SOCK="${SSH_AUTH_SOCK:-}" \
   NIX_CONFIG="${NIX_CONFIG:-}" \
-  nixos-install --root "$TARGET" --flake "$CONFIG_DEST#$HOST"
+  GPG_TTY="$(tty)" \
+  nixos-install --no-root-passwd --root "$TARGET" --flake "$CONFIG_DEST#$HOST"
 
 echo "✅ nixos-install completed."

--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -1,243 +1,186 @@
 #!/usr/bin/env -S nix shell nixpkgs#bashInteractive nixpkgs#coreutils nixpkgs#git nixpkgs#openssh nixpkgs#gnupg nixpkgs#pcsclite nixpkgs#age nixpkgs#age-plugin-yubikey --command bash
+# bootstrap/install.sh — NixOS (Linux) bootstrap
+#
+# Bootstraps a fresh NixOS install:
+#   1. Configures GPG smartcard / pcscd coexistence
+#   2. Clones nixos-config + nix-secrets into the target via YubiKey SSH auth
+#   3. Decrypts the YubiKey-encrypted age identity blob → /var/lib/age/keys.txt
+#   4. Optionally runs nixos-install
+#
+# Run as your normal user (not root). sudo is used only for target root paths.
+# The shebang pulls all required tools from nixpkgs via `nix shell` so the
+# script is self-contained on any system with Nix available.
+#
+# For testing without the nix shell re-exec, set:
+#   _NIXOS_BOOTSTRAP_NIX_SHELL=1 bash bootstrap/install.sh ...
 set -euo pipefail
 
+# ---------------------------------------------------------------------------
+# Phase 1: ensure we are running inside the nix shell tool environment
+# The shebang handles this in normal use; the env var bypass is for tests.
+# ---------------------------------------------------------------------------
+if [[ "${_NIXOS_BOOTSTRAP_NIX_SHELL:-0}" != "1" ]]; then
+  # When invoked as `bash install.sh` the shebang is skipped but we still
+  # need the tool environment. Re-exec under nix shell.
+  exec env _NIXOS_BOOTSTRAP_NIX_SHELL=1 \
+    nix shell \
+      nixpkgs#bashInteractive \
+      nixpkgs#coreutils \
+      nixpkgs#git \
+      nixpkgs#openssh \
+      nixpkgs#gnupg \
+      nixpkgs#pcsclite \
+      nixpkgs#age \
+      nixpkgs#age-plugin-yubikey \
+      --command bash -- "$0" "$@"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 2: running inside the tool environment
+# ---------------------------------------------------------------------------
+export PLATFORM="linux"
+SCRIPT_NAME="install.sh"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
-die() { echo "ERROR: $*" >&2; exit 1; }
-
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
 usage() {
+  usage_common
   cat <<EOF
-Usage: bootstrap/install.sh [--target /mnt] [--user username] [--uid 1000] [--gid 100] [--host hostname] [--dry-run|--install] [--config-dest PATH] [--secrets-subdir PATH] [--secrets-blob PATH]
 
-This script bootstraps a fresh NixOS install using a single YubiKey:
+Linux-specific options:
+  --target PATH   Target mountpoint for the new system (default: /mnt)
 
-  - Ensures pcscd + gpg smartcard coexist cleanly (scdaemon disable-ccid)
-  - Uses YubiKey-backed SSH auth to clone:
-      - nixos-config into <config-dest>
-      - nix-secrets into <config-dest>/<secrets-subdir>
-  - Decrypts YubiKey-encrypted age identity blob from nix-secrets:
-      - writes <target>/var/lib/age/keys.txt
-  - (--install) runs nixos-install using the cloned nixos-config flake
+Examples:
+  # Dry-run (clone + decrypt, then show next steps)
+  bootstrap/install.sh --host gibson
 
-Options:
-  --target PATH         Target mountpoint (default: /mnt)
-  --user NAME           Username for target home path (default: rickie)
-  --uid N               UID for ownership of <target>/home/<user> (default: 1000)
-  --gid N               GID for ownership of <target>/home/<user> (default: 100)
-  --host NAME           Hostname to install (default: gibson)
-  --dry-run             Do not run nixos-install (default)
-  --install             Run nixos-install after bootstrapping secrets
-  --config-dest PATH    Where to place nixos-config in the target
-                        (default: <target>/home/<user>/nixos-config)
-  --secrets-subdir PATH Where nix-secrets is cloned relative to config-dest
-                        (default: secrets)
-  --secrets-blob PATH   Path to the encrypted age identity blob inside nix-secrets
-                        (default: bootstrap/age-keys.txt.age)
-  --help                Show this help
+  # Full install
+  bootstrap/install.sh --host gibson --install
+
+  # Custom target
+  bootstrap/install.sh --target /mnt --user rickie --host gibson --install
 
 Notes:
-  - Run this as your normal user, not with sudo.
-    The script will sudo only for the few target root paths it must write.
-  - Requires the YubiKey to be plugged in, you will be prompted to touch it.
-  - Uses your existing SSH, YubiKey setup to access GitHub (git@github.com).
+  - Run as your normal user, not root.
+  - YubiKey must be plugged in; you will be prompted to touch it.
 EOF
 }
 
-TARGET="/mnt"
-HOST="gibson"
-USER_NAME="rickie"
-USER_UID="1000"
-USER_GID="100"
-DO_INSTALL=0
-CONFIG_DEST=""
-SECRETS_SUBDIR="secrets"
-SECRETS_BLOB_REL="bootstrap/age-keys.txt.age"
+# ---------------------------------------------------------------------------
+# Argument parsing — handle --target here, delegate the rest to common
+# ---------------------------------------------------------------------------
+arg_defaults
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --target) TARGET="$2"; shift 2;;
-    --host) HOST="$2"; shift 2;;
-    --user) USER_NAME="$2"; shift 2;;
-    --uid) USER_UID="$2"; shift 2;;
-    --gid) USER_GID="$2"; shift 2;;
-    --install) DO_INSTALL=1; shift;;
-    --dry-run) DO_INSTALL=0; shift;;
-    --config-dest) CONFIG_DEST="$2"; shift 2;;
-    --secrets-subdir) SECRETS_SUBDIR="$2"; shift 2;;
-    --secrets-blob) SECRETS_BLOB_REL="$2"; shift 2;;
-    --help|-h) usage; exit 0;;
-    *) die "Unknown arg: $1";;
+REMAINING_ARGS=()
+_raw=("$@")
+_filtered=()
+while [[ ${#_raw[@]} -gt 0 ]]; do
+  case "${_raw[0]}" in
+    --target) TARGET="${_raw[1]}"; _raw=("${_raw[@]:2}") ;;
+    *)        _filtered+=("${_raw[0]}"); _raw=("${_raw[@]:1}") ;;
   esac
 done
+parse_common_args "${_filtered[@]+"${_filtered[@]}"}"
 
+[[ ${#REMAINING_ARGS[@]} -eq 0 ]] \
+  || die "Unknown argument(s): ${REMAINING_ARGS[*]}"
+
+# ---------------------------------------------------------------------------
+# Derived paths
+# ---------------------------------------------------------------------------
 [[ -n "$CONFIG_DEST" ]] || CONFIG_DEST="$TARGET/home/$USER_NAME/nixos-config"
 
-MODE="dry-run"
-[[ $DO_INSTALL -eq 1 ]] && MODE="install"
+# Verify config dest is inside the target — catches typos before anything destructive
+[[ "$CONFIG_DEST" == "$TARGET"* ]] \
+  || die "--config-dest ($CONFIG_DEST) is not under --target ($TARGET)"
 
-NIXOS_CONFIG_ORIGIN="git@github.com:5ysk3y/nixos-config.git"
-NIX_SECRETS_ORIGIN="git@github.com:5ysk3y/nix-secrets.git"
-NIX_SECRETS_BRANCH="main"
-
-# --- Paths in the TARGET filesystem ---
 USER_HOME="$TARGET/home/$USER_NAME"
 AGE_KEYS_DIR="$TARGET/var/lib/age"
 AGE_KEYS_FILE="$AGE_KEYS_DIR/keys.txt"
-
 CONFIG_PARENT="$(dirname "$CONFIG_DEST")"
-SECRETS_DEST="$CONFIG_DEST/$SECRETS_SUBDIR"
+SECRETS_DEST="$(dirname "$CONFIG_DEST")/$SECRETS_SUBDIR"
 SECRETS_BLOB="$SECRETS_DEST/$SECRETS_BLOB_REL"
 
-TMPDIR="$(mktemp -d)"
-YUBI_IDENT="$TMPDIR/yubikey-identity.txt"
-CLEANUP_DONE=0
-cleanup() {
-  if [[ $CLEANUP_DONE -eq 0 ]]; then
-    rm -rf "$TMPDIR"
-    CLEANUP_DONE=1
-  fi
-}
-trap cleanup EXIT
+MODE="dry-run"; [[ $DO_INSTALL -eq 1 ]] && MODE="install"
 
-# Use sudo only when needed
-SUDO=""
-if [[ ${EUID:-0} -ne 0 ]]; then
-  command -v sudo >/dev/null 2>&1 || die "This script needs sudo available for a few steps when not run as root."
-  SUDO="sudo"
-fi
+resolve_sudo
 
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
 echo "=== NixOS bootstrap (YubiKey-first) ==="
-echo "Repo root:     $ROOT_DIR"
-echo "Target:        $TARGET"
-echo "User:          $USER_NAME ($USER_UID:$USER_GID)"
-echo "Host:          $HOST"
-echo "Mode:          $MODE"
-echo "Config dest:   $CONFIG_DEST"
-echo "Secrets dest:  $SECRETS_DEST"
-echo "Secrets blob:  $SECRETS_BLOB_REL"
+echo "Repo root    : $ROOT_DIR"
+echo "Target       : $TARGET"
+echo "User         : $USER_NAME ($USER_UID:$USER_GID)"
+echo "Host         : $HOST"
+echo "Mode         : $MODE"
+echo "Config dest  : $CONFIG_DEST"
+echo "Secrets dest : $SECRETS_DEST"
+echo "Secrets blob : $SECRETS_BLOB_REL"
+echo "Age key file : $AGE_KEYS_FILE"
 echo
 
 [[ -d "$TARGET" ]] || die "Target path does not exist: $TARGET"
 
+# ---------------------------------------------------------------------------
+# Prepare target directory tree
+# ---------------------------------------------------------------------------
 echo "Preparing target directories..."
-# These may fail if TARGET is root-owned, that’s fine, we fall back to sudo
-mkdir -p "$TARGET/etc/nixos" "$USER_HOME" "$CONFIG_PARENT" 2>/dev/null || true
-$SUDO mkdir -p "$TARGET/etc/nixos" "$USER_HOME" "$CONFIG_PARENT"
-$SUDO mkdir -p "$TARGET/var/lib" "$AGE_KEYS_DIR"
+$SUDO mkdir -p "$TARGET/etc/nixos" "$USER_HOME" "$CONFIG_PARENT" \
+               "$TARGET/var/lib" "$AGE_KEYS_DIR"
+$SUDO chown "$USER_UID:$USER_GID" "$USER_HOME" 2>/dev/null || true
 
-$SUDO chown -R "$USER_UID:$USER_GID" "$USER_HOME" >/dev/null 2>&1 || true
+# ---------------------------------------------------------------------------
+# Bootstrap steps
+# ---------------------------------------------------------------------------
+setup_gpg_smartcard
+setup_known_hosts
+check_yubikey_age
 
-# --- Ensure smartcard plumbing works cleanly (pcscd + GPG coexistence) ---
-# We configure scdaemon disable-ccid for the CURRENT user running the script.
-GNUPG_HOME="${GNUPGHOME:-$HOME/.gnupg}"
-mkdir -p "$GNUPG_HOME"
-chmod 700 "$GNUPG_HOME"
+clone_or_update_repo "nixos-config" "$NIXOS_CONFIG_ORIGIN" "$CONFIG_DEST"
+clone_or_update_repo "nix-secrets"  "$NIX_SECRETS_ORIGIN"  "$SECRETS_DEST" "$NIX_SECRETS_BRANCH"
 
-SCDAEMON_CONF="$GNUPG_HOME/scdaemon.conf"
-if ! grep -qx 'disable-ccid' "$SCDAEMON_CONF" 2>/dev/null; then
-  echo "Configuring GnuPG scdaemon to avoid CCID conflicts (disable-ccid)..."
-  echo "disable-ccid" >> "$SCDAEMON_CONF"
-fi
+$SUDO chown -R "$USER_UID:$USER_GID" "$CONFIG_DEST" "$SECRETS_DEST" 2>/dev/null || true
 
-echo "Restarting smartcard daemons..."
-gpgconf --kill scdaemon >/dev/null 2>&1 || true
-gpgconf --kill gpg-agent >/dev/null 2>&1 || true
+# root_owned=true: Linux age key lives at /var/lib/age/keys.txt, owned root:root
+# sops-nix reads it at activation time with the system identity.
+decrypt_age_blob "$SECRETS_BLOB" "$AGE_KEYS_DIR" "$AGE_KEYS_FILE" "true"
 
-if command -v systemctl >/dev/null 2>&1; then
-  $SUDO systemctl restart pcscd >/dev/null 2>&1 || true
-else
-  $SUDO pkill pcscd >/dev/null 2>&1 || true
-  $SUDO pcscd >/dev/null 2>&1 || true
-fi
-
-# --- Ensure SSH can talk to GitHub (known_hosts) ---
-SSH_DIR="${HOME}/.ssh"
-KNOWN_HOSTS="${SSH_DIR}/known_hosts"
-mkdir -p "$SSH_DIR"
-chmod 700 "$SSH_DIR"
-touch "$KNOWN_HOSTS"
-chmod 600 "$KNOWN_HOSTS"
-
-if ! ssh-keygen -F github.com -f "$KNOWN_HOSTS" >/dev/null 2>&1; then
-  echo "Adding github.com to known_hosts..."
-  ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> "$KNOWN_HOSTS" 2>/dev/null || true
-fi
-
-# --- Quick probe that the YubiKey age plugin sees a key ---
-echo "Checking YubiKey age identities..."
-AGE_RECIP="$(age-plugin-yubikey --list | grep . | tail -n1 || true)"
-[[ -n "$AGE_RECIP" ]] || die "No YubiKey age recipients found. Expected 'age-plugin-yubikey --list' to show at least one. Is the YubiKey inserted and usable?"
-
-echo "Using YubiKey recipient: $AGE_RECIP"
-echo
-
-# --- Clone nixos-config into target, IMPORTANT: runs as invoking user so SSH agent works ---
-if [[ -d "$CONFIG_DEST/.git" ]]; then
-  echo "nixos-config already exists at $CONFIG_DEST, fetching latest..."
-  git -C "$CONFIG_DEST" fetch --all --prune
-else
-  echo "Cloning nixos-config into $CONFIG_DEST..."
-  $SUDO rm -rf "$CONFIG_DEST" >/dev/null 2>&1 || true
-  rm -rf "$CONFIG_DEST"
-  git clone "$NIXOS_CONFIG_ORIGIN" "$CONFIG_DEST"
-fi
-
-# --- Clone nix-secrets under nixos-config tree ---
-if [[ -d "$SECRETS_DEST/.git" ]]; then
-  echo "nix-secrets already exists at $SECRETS_DEST, fetching latest..."
-  git -C "$SECRETS_DEST" fetch --all --prune
-  git -C "$SECRETS_DEST" checkout "$NIX_SECRETS_BRANCH"
-  git -C "$SECRETS_DEST" reset --hard "origin/$NIX_SECRETS_BRANCH"
-else
-  echo "Cloning nix-secrets into $SECRETS_DEST..."
-  mkdir -p "$(dirname "$SECRETS_DEST")"
-  rm -rf "$SECRETS_DEST"
-  git clone --branch "$NIX_SECRETS_BRANCH" "$NIX_SECRETS_ORIGIN" "$SECRETS_DEST"
-fi
-
-# Ownership of the config tree should belong to the target user
-$SUDO chown -R "$USER_UID:$USER_GID" "$CONFIG_DEST" >/dev/null 2>&1 || true
-
-# --- Decrypt the YubiKey-encrypted age identity blob into the target root ---
-[[ -f "$SECRETS_BLOB" ]] || die "Missing secrets blob: $SECRETS_BLOB"
-
-echo
-echo "Generating YubiKey identity descriptor (non-secret)..."
-age-plugin-yubikey --identity > "$YUBI_IDENT"
-
-echo "Decrypting age identity blob, requires YubiKey touch..."
-$SUDO install -d -m 0700 "$AGE_KEYS_DIR"
-$SUDO age -d -i "$YUBI_IDENT" -o "$AGE_KEYS_FILE" "$SECRETS_BLOB"
-$SUDO chmod 0600 "$AGE_KEYS_FILE"
-$SUDO chown root:root "$AGE_KEYS_FILE"
-
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
 echo
 echo "✅ Bootstrap complete."
 echo
-echo "What exists in target now:"
-echo "  - $CONFIG_DEST                     -> nixos-config (git clone)"
-echo "  - $SECRETS_DEST                    -> nix-secrets  (git clone)"
-echo "  - $AGE_KEYS_FILE                   -> sops-nix age keyFile on installed system"
+echo "  $CONFIG_DEST   → nixos-config"
+echo "  $SECRETS_DEST  → nix-secrets"
+echo "  $AGE_KEYS_FILE → sops-nix age keyFile"
 echo
 
 if [[ $DO_INSTALL -eq 0 ]]; then
-  echo "Next steps:"
-  echo "  1) Review config at: $CONFIG_DEST"
-  echo "  2) Run: nixos-install --root $TARGET --flake $CONFIG_DEST#$HOST"
+  echo "Dry-run — next steps:"
+  echo "  1. Review: $CONFIG_DEST"
+  echo "  2. Run:    nixos-install --root $TARGET --flake $CONFIG_DEST#$HOST"
   exit 0
 fi
 
-echo "=== Install mode ==="
+# ---------------------------------------------------------------------------
+# Install mode
+# ---------------------------------------------------------------------------
+echo "=== Running nixos-install ==="
+[[ -d "$TARGET/etc"      ]] || die "Target sanity check failed: $TARGET/etc missing"
+[[ -f "$AGE_KEYS_FILE"   ]] || die "Age key missing: $AGE_KEYS_FILE"
+[[ -d "$CONFIG_DEST/.git" ]] || die "nixos-config clone missing: $CONFIG_DEST"
 
-[[ -d "$TARGET/etc" ]] || die "Target looks wrong: $TARGET/etc missing"
-[[ -f "$AGE_KEYS_FILE" ]] || die "Age key missing at $AGE_KEYS_FILE"
-[[ -d "$CONFIG_DEST/.git" ]] || die "nixos-config clone missing at $CONFIG_DEST"
-
-echo "Running nixos-install..."
-# Keep essentials (especially SSH_AUTH_SOCK) so git+ssh flake inputs can work during install if needed.
+# Preserve SSH_AUTH_SOCK so flake SSH inputs (nix-secrets) resolve during install.
 $SUDO env -i \
   HOME="$HOME" \
-  USER="$USER" \
+  USER="${USER:-$USER_NAME}" \
   PATH="$PATH" \
   SSH_AUTH_SOCK="${SSH_AUTH_SOCK:-}" \
   NIX_CONFIG="${NIX_CONFIG:-}" \

--- a/bootstrap/test.sh
+++ b/bootstrap/test.sh
@@ -1,0 +1,650 @@
+#!/usr/bin/env bash
+# bootstrap/test.sh — test harness for the bootstrap scripts
+#
+# Tests common.sh, install.sh, and install-darwin.sh without a real YubiKey,
+# network, or target system. All external commands are stubbed via PATH injection.
+#
+# install.sh tests bypass nix-shell re-exec via _NIXOS_BOOTSTRAP_NIX_SHELL=1
+# install-darwin.sh tests bypass it via _DARWIN_BOOTSTRAP_NIX_SHELL=1
+#
+# Usage:
+#   bash bootstrap/test.sh           # run all tests
+#   bash bootstrap/test.sh -v        # verbose
+#   bash bootstrap/test.sh -k clone  # filter by name substring
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_SH="$SCRIPT_DIR/common.sh"
+INSTALL_LINUX="$SCRIPT_DIR/install.sh"
+INSTALL_DARWIN="$SCRIPT_DIR/install-darwin.sh"
+
+# ---------------------------------------------------------------------------
+# Framework
+# ---------------------------------------------------------------------------
+_PASS=0; _FAIL=0; _SKIP=0
+VERBOSE=0; FILTER=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -v) VERBOSE=1; shift ;;
+    -k) FILTER="$2"; shift 2 ;;
+    *)  echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+_grp=""
+describe() { _grp="$1"; }
+
+it() {
+  local desc="$1"; shift
+  local name="${_grp}: ${desc}"
+  if [[ -n "$FILTER" ]] && [[ "$name" != *"$FILTER"* ]]; then
+    (( _SKIP++ )) || true; return
+  fi
+  [[ $VERBOSE -eq 1 ]] && echo "  ▶ $name"
+  if "$@" >/dev/null 2>&1; then
+    (( _PASS++ )) || true; echo "  ✅ $name"
+  else
+    (( _FAIL++ )) || true; echo "  ❌ $name"
+    "$@" 2>&1 | sed 's/^/      /' || true
+  fi
+}
+
+summary() {
+  echo; echo "Results: ${_PASS} passed, ${_FAIL} failed, ${_SKIP} skipped"
+  [[ $_FAIL -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# _setup: initialise T and BIN local variables in the CALLING function.
+# Usage at top of each test:  local T BIN; _setup
+# The caller is responsible for cleanup: trap "rm -rf '$T'" RETURN
+_setup() {
+  # Use nameref-style via printf to set caller's locals.
+  # We can't use namerefs (bash 4.3+) portably, so instead _setup prints
+  # the paths and callers eval them. Simpler: just let each test inline it.
+  : # intentionally empty — see pattern in tests below
+}
+
+# _stub <BIN> <name> [output]: write a stub that exits 0
+_stub() {
+  local bin="$1" name="$2" output="${3:-}"
+  { printf '#!/usr/bin/env bash\n'; [[ -n "$output" ]] && printf 'echo "%s"\n' "$output"; printf 'exit 0\n'; } \
+    > "$bin/$name"
+  chmod +x "$bin/$name"
+}
+
+# _git_stub <BIN>: git that creates fake .git + bootstrap blob on clone
+_git_stub() {
+  local bin="$1"
+  cat > "$bin/git" << 'GEOF'
+#!/usr/bin/env bash
+if [[ "$1" == clone ]]; then
+  mkdir -p "${@: -1}/.git"
+  mkdir -p "${@: -1}/bootstrap"
+  touch "${@: -1}/bootstrap/age-keys.txt.age"
+fi
+exit 0
+GEOF
+  chmod +x "$bin/git"
+}
+
+# _common_stubs <BIN>: all stubs needed to pass setup_* + clone in install scripts
+_common_stubs() {
+  local bin="$1"
+  _stub "$bin" gpgconf
+  _stub "$bin" systemctl
+  _stub "$bin" ssh-keygen "github.com found"
+  _stub "$bin" ssh-keyscan
+  _stub "$bin" age-plugin-yubikey "age1yubikey1fakerecipient"
+  # gpg stub: list-keys exits 0 (key present), fetch-keys and card-status succeed silently
+  cat > "$bin/gpg" << 'GEOF'
+#!/usr/bin/env bash
+case "$1" in
+  --list-keys)  exit 0 ;;
+  --fetch-keys) exit 0 ;;
+  --card-status) exit 0 ;;
+  *) exit 0 ;;
+esac
+GEOF
+  chmod +x "$bin/gpg"
+  # sudo stub: silently succeed for chown/install-d (ownership ops that require root)
+  # and exec everything else. This prevents both: real sudo prompting on macOS,
+  # and chown root:root failing as non-root on macOS.
+  cat > "$bin/sudo" << 'SEOF'
+#!/usr/bin/env bash
+# Skip ownership changes silently — in test environments dirs are already user-owned
+case "$1" in
+  chown) exit 0 ;;
+  install) [[ "$*" == *"-d"* ]] && { shift; exec install "$@"; } || exit 0 ;;
+esac
+exec "$@"
+SEOF
+  chmod +x "$bin/sudo"
+  # age stub: parse -o <file> and create a fake key file there so chmod/chown succeed
+  cat > "$bin/age" << 'AEOF'
+#!/usr/bin/env bash
+prev=""
+for a in "$@"; do
+  if [[ "$prev" == "-o" ]]; then
+    mkdir -p "$(dirname "$a")"
+    echo "AGE-SECRET-KEY-FAKE" > "$a"
+  fi
+  prev="$a"
+done
+exit 0
+AEOF
+  chmod +x "$bin/age"
+  _git_stub "$bin"
+}
+
+# ---------------------------------------------------------------------------
+# ── common.sh sourcing ──────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+describe "common.sh sourcing"
+
+_t_refuses_direct_exec() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local out; out="$(bash "$COMMON_SH" 2>&1 || true)"
+  [[ "$out" == *"must be sourced"* ]]
+}
+it "refuses direct execution" _t_refuses_direct_exec
+
+_t_fails_no_platform() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local out; out="$(SCRIPT_NAME=test bash -c "source '$COMMON_SH'" 2>&1 || true)"
+  [[ "$out" == *"PLATFORM must be"* ]]
+}
+it "fails when PLATFORM is unset" _t_fails_no_platform
+
+_t_fails_no_scriptname() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local out; out="$(bash -c "export PLATFORM=linux; source '$COMMON_SH'" 2>&1 || true)"
+  [[ "$out" == *"SCRIPT_NAME must be"* ]]
+}
+it "fails when SCRIPT_NAME is unset" _t_fails_no_scriptname
+
+_t_fails_bad_platform() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local out; out="$(PLATFORM=windows SCRIPT_NAME=test bash -c "source '$COMMON_SH'" 2>&1 || true)"
+  [[ "$out" == *"PLATFORM must be"* ]]
+}
+it "fails with invalid PLATFORM value" _t_fails_bad_platform
+
+_t_sources_linux() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  bash -c "export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'"
+}
+it "sources cleanly for linux" _t_sources_linux
+
+_t_sources_darwin() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  bash -c "export PLATFORM=darwin; SCRIPT_NAME=test source '$COMMON_SH'"
+}
+it "sources cleanly for darwin" _t_sources_darwin
+
+# ---------------------------------------------------------------------------
+describe "arg_defaults"
+
+_t_defaults_linux() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'
+    arg_defaults
+    [[ \$TARGET == '/mnt' ]] && [[ \$HOST == 'gibson' ]] && [[ \$USER_NAME == 'rickie' ]]
+  "
+}
+it "linux: TARGET=/mnt HOST=gibson USER=rickie" _t_defaults_linux
+
+_t_defaults_darwin() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  bash -c "
+    export PLATFORM=darwin; SCRIPT_NAME=test source '$COMMON_SH'
+    arg_defaults
+    [[ \$TARGET == '/' ]] && [[ \$HOST == 'macbook' ]]
+  "
+}
+it "darwin: TARGET=/ HOST=macbook" _t_defaults_darwin
+
+# ---------------------------------------------------------------------------
+describe "parse_common_args"
+
+_t_parse_user() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  bash -c "export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'; arg_defaults; REMAINING_ARGS=(); parse_common_args --user bob; [[ \$USER_NAME == 'bob' ]]"
+}
+it "parses --user" _t_parse_user
+
+_t_parse_host() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  bash -c "export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'; arg_defaults; REMAINING_ARGS=(); parse_common_args --host myhost; [[ \$HOST == 'myhost' ]]"
+}
+it "parses --host" _t_parse_host
+
+_t_parse_install() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  bash -c "export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'; arg_defaults; REMAINING_ARGS=(); parse_common_args --install; [[ \$DO_INSTALL -eq 1 ]]"
+}
+it "parses --install sets DO_INSTALL=1" _t_parse_install
+
+_t_parse_dryrun() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  bash -c "export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'; arg_defaults; REMAINING_ARGS=(); parse_common_args --install --dry-run; [[ \$DO_INSTALL -eq 0 ]]"
+}
+it "parses --dry-run overrides --install" _t_parse_dryrun
+
+_t_parse_secrets_subdir() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  bash -c "export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'; arg_defaults; REMAINING_ARGS=(); parse_common_args --secrets-subdir mysecrets; [[ \$SECRETS_SUBDIR == 'mysecrets' ]]"
+}
+it "parses --secrets-subdir" _t_parse_secrets_subdir
+
+_t_parse_remaining() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'
+    arg_defaults; REMAINING_ARGS=()
+    parse_common_args --user alice --bogus --another
+    [[ \${#REMAINING_ARGS[@]} -eq 2 ]] && [[ \${REMAINING_ARGS[0]} == '--bogus' ]] && [[ \${REMAINING_ARGS[1]} == '--another' ]]
+  "
+}
+it "accumulates unknown flags in REMAINING_ARGS" _t_parse_remaining
+
+# ---------------------------------------------------------------------------
+describe "setup_known_hosts"
+
+_t_kh_creates_and_scans() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  printf '#!/usr/bin/env bash\nexit 1\n'                             > "$BIN/ssh-keygen";  chmod +x "$BIN/ssh-keygen"
+  printf '#!/usr/bin/env bash\necho "github.com ssh-rsa FAKE"\n'    > "$BIN/ssh-keyscan"; chmod +x "$BIN/ssh-keyscan"
+  PATH="$BIN:$PATH" HOME="$T/home" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'; setup_known_hosts
+  "
+  [[ -f "$T/home/.ssh/known_hosts" ]]
+}
+it "creates SSH dir + known_hosts, calls ssh-keyscan when key absent" _t_kh_creates_and_scans
+
+_t_kh_skips_scan() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/ssh-keygen";  chmod +x "$BIN/ssh-keygen"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$BIN/ssh-keyscan"; chmod +x "$BIN/ssh-keyscan"
+  mkdir -p "$T/home/.ssh"; touch "$T/home/.ssh/known_hosts"
+  PATH="$BIN:$PATH" HOME="$T/home" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'; setup_known_hosts
+  "
+}
+it "skips ssh-keyscan when key already present" _t_kh_skips_scan
+
+_t_kh_fails_loud() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$BIN/ssh-keygen";  chmod +x "$BIN/ssh-keygen"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$BIN/ssh-keyscan"; chmod +x "$BIN/ssh-keyscan"
+  mkdir -p "$T/home/.ssh"
+  local out; out="$(PATH="$BIN:$PATH" HOME="$T/home" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'; setup_known_hosts
+  " 2>&1 || true)"
+  [[ "$out" == *"failed"* ]]
+}
+it "dies with clear message when ssh-keyscan fails" _t_kh_fails_loud
+
+# ---------------------------------------------------------------------------
+describe "check_yubikey_age"
+
+_t_yubi_found() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  printf '#!/usr/bin/env bash\necho age1yubikey1fakerecipient\n' > "$BIN/age-plugin-yubikey"; chmod +x "$BIN/age-plugin-yubikey"
+  PATH="$BIN:$PATH" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'; check_yubikey_age
+  "
+}
+it "passes when age-plugin-yubikey lists a recipient" _t_yubi_found
+
+_t_yubi_missing() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  printf '#!/usr/bin/env bash\n' > "$BIN/age-plugin-yubikey"; chmod +x "$BIN/age-plugin-yubikey"
+  local out; out="$(PATH="$BIN:$PATH" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'; check_yubikey_age
+  " 2>&1 || true)"
+  echo "$out" | grep -qi 'no yubikey'
+}
+it "dies when no recipients found" _t_yubi_missing
+
+# ---------------------------------------------------------------------------
+describe "setup_gpg_smartcard"
+
+_t_gpg_enables_ssh_support() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  _stub "$BIN" gpgconf
+  _stub "$BIN" systemctl
+  # gpg stub: list-keys exits 0 (key present), card-status succeeds
+  cat > "$BIN/gpg" << 'GEOF'
+#!/usr/bin/env bash
+exit 0
+GEOF
+  chmod +x "$BIN/gpg"
+  local GNUPGHOME="$T/.gnupg"; mkdir -p "$GNUPGHOME"
+  PATH="$BIN:$PATH" HOME="$T" GNUPGHOME="$GNUPGHOME" SUDO="" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'
+    GPG_KEY_URL='https://example.com/fake.gpg'
+    setup_gpg_smartcard
+  "
+  grep -qx 'enable-ssh-support' "$GNUPGHOME/gpg-agent.conf"
+}
+it "writes enable-ssh-support to gpg-agent.conf" _t_gpg_enables_ssh_support
+
+_t_gpg_imports_key_when_absent() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  _stub "$BIN" gpgconf
+  _stub "$BIN" systemctl
+  local CALLS="$T/calls"
+  # gpg stub: list-keys exits 1 (key absent), record all calls
+  cat > "$BIN/gpg" << GEOF
+#!/usr/bin/env bash
+echo "gpg \$@" >> "$CALLS"
+case "\$1" in
+  --list-keys) exit 1 ;;
+  *) exit 0 ;;
+esac
+GEOF
+  chmod +x "$BIN/gpg"
+  PATH="$BIN:$PATH" HOME="$T" GNUPGHOME="$T/.gnupg" SUDO="" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'
+    GPG_KEY_URL='https://example.com/fake.gpg'
+    setup_gpg_smartcard
+  " 2>/dev/null || true
+  grep -q 'fetch-keys' "$CALLS"
+}
+it "imports GPG key when not in keyring" _t_gpg_imports_key_when_absent
+
+_t_gpg_skips_import_when_present() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  _stub "$BIN" gpgconf
+  _stub "$BIN" systemctl
+  local CALLS="$T/calls"
+  # gpg stub: list-keys exits 0 (key present), record all calls
+  cat > "$BIN/gpg" << GEOF
+#!/usr/bin/env bash
+echo "gpg \$@" >> "$CALLS"
+exit 0
+GEOF
+  chmod +x "$BIN/gpg"
+  PATH="$BIN:$PATH" HOME="$T" GNUPGHOME="$T/.gnupg" SUDO="" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'
+    GPG_KEY_URL='https://example.com/fake.gpg'
+    setup_gpg_smartcard
+  " 2>/dev/null || true
+  ! grep -q 'fetch-keys' "$CALLS"
+}
+it "skips GPG key import when already in keyring" _t_gpg_skips_import_when_present
+
+_t_gpg_dies_on_missing_card() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  _stub "$BIN" gpgconf
+  _stub "$BIN" systemctl
+  # gpg stub: card-status exits 1 (YubiKey not present)
+  cat > "$BIN/gpg" << 'GEOF'
+#!/usr/bin/env bash
+case "$1" in
+  --card-status) exit 1 ;;
+  *) exit 0 ;;
+esac
+GEOF
+  chmod +x "$BIN/gpg"
+  local out; out="$(PATH="$BIN:$PATH" HOME="$T" GNUPGHOME="$T/.gnupg" SUDO="" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'
+    GPG_KEY_URL='https://example.com/fake.gpg'
+    setup_gpg_smartcard
+  " 2>&1 || true)"
+  [[ "$out" == *"YubiKey not detected"* ]]
+}
+it "dies with clear message when YubiKey not detected" _t_gpg_dies_on_missing_card
+
+_t_gpg_exports_ssh_auth_sock() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  _stub "$BIN" systemctl
+  # gpgconf stub: return a fake SSH socket path for agent-ssh-socket
+  cat > "$BIN/gpgconf" << GEOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"agent-ssh-socket"* ]]; then
+  echo "$T/S.gpg-agent.ssh"
+fi
+exit 0
+GEOF
+  chmod +x "$BIN/gpgconf"
+  _stub "$BIN" gpg
+  local result
+  result="$(PATH="$BIN:$PATH" HOME="$T" GNUPGHOME="$T/.gnupg" SUDO="" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'
+    GPG_KEY_URL='https://example.com/fake.gpg'
+    setup_gpg_smartcard
+    echo "\$SSH_AUTH_SOCK"
+  " 2>/dev/null || true)"
+  [[ "$result" == *"S.gpg-agent.ssh"* ]]
+}
+it "exports SSH_AUTH_SOCK pointing at gpg-agent SSH socket" _t_gpg_exports_ssh_auth_sock
+
+# ---------------------------------------------------------------------------
+describe "clone_or_update_repo"
+
+_t_clone_fresh() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  cat > "$BIN/git" << 'GEOF'
+#!/usr/bin/env bash
+[[ "$1" == clone ]] && mkdir -p "${@: -1}/.git"
+exit 0
+GEOF
+  chmod +x "$BIN/git"
+  local DEST="$T/repo"
+  PATH="$BIN:$PATH" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'
+    clone_or_update_repo label git@x:r.git '$DEST'
+  "
+  [[ -d "$DEST/.git" ]]
+}
+it "clones when dest does not exist" _t_clone_fresh
+
+_t_clone_update_no_branch() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  local CALLS="$T/calls"
+  mkdir -p "$T/repo/.git"
+  cat > "$BIN/git" << GEOF
+#!/usr/bin/env bash
+echo "\$@" >> "$CALLS"
+exit 0
+GEOF
+  chmod +x "$BIN/git"
+  PATH="$BIN:$PATH" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'
+    clone_or_update_repo label git@x:r.git '$T/repo'
+  "
+  grep -q 'fetch'  "$CALLS"
+  grep -q 'merge'  "$CALLS"
+  ! grep -q 'reset --hard' "$CALLS"
+}
+it "fetches + fast-forwards (no branch), never hard-resets" _t_clone_update_no_branch
+
+_t_clone_update_with_branch() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  local CALLS="$T/calls"
+  mkdir -p "$T/repo/.git"
+  cat > "$BIN/git" << GEOF
+#!/usr/bin/env bash
+echo "\$@" >> "$CALLS"
+exit 0
+GEOF
+  chmod +x "$BIN/git"
+  PATH="$BIN:$PATH" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'
+    clone_or_update_repo secrets git@x:s.git '$T/repo' main
+  "
+  grep -q 'reset --hard origin/main' "$CALLS"
+}
+it "hard-resets to branch when branch specified" _t_clone_update_with_branch
+
+# ---------------------------------------------------------------------------
+describe "decrypt_age_blob"
+
+_t_decrypt_linux() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"
+  mkdir -p "$T/secrets/bootstrap"
+  echo 'blob' > "$T/secrets/bootstrap/age-keys.txt.age"
+  cat > "$BIN/age" << 'AEOF'
+#!/usr/bin/env bash
+prev=""
+for a in "$@"; do
+  [[ "$prev" == "-o" ]] && echo "AGE-SECRET-KEY-FAKE" > "$a"
+  prev="$a"
+done
+exit 0
+AEOF
+  chmod +x "$BIN/age"
+  printf '#!/usr/bin/env bash\necho identity\n' > "$BIN/age-plugin-yubikey"; chmod +x "$BIN/age-plugin-yubikey"
+  local KEYS_DIR="$T/keys" KEYS_FILE="$T/keys/keys.txt"
+  mkdir -p "$KEYS_DIR"
+  local BLOB="$T/secrets/bootstrap/age-keys.txt.age"
+  T="$T" BIN="$BIN" KEYS_DIR="$KEYS_DIR" KEYS_FILE="$KEYS_FILE" BLOB="$BLOB" \
+  PATH="$BIN:$PATH" bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'
+    SUDO=''
+    YUBI_IDENT=\"\$T/yubi.txt\"
+    decrypt_age_blob \"\$BLOB\" \"\$KEYS_DIR\" \"\$KEYS_FILE\" 'true'
+  "
+  [[ -f "$KEYS_FILE" ]]
+}
+it "linux: decrypts blob, writes key file (root_owned=true)" _t_decrypt_linux
+
+_t_decrypt_missing() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local out; out="$(bash -c "
+    export PLATFORM=linux; SCRIPT_NAME=test source '$COMMON_SH'
+    SUDO=''; decrypt_age_blob '/no/blob.age' '/k' '/k/k.txt' 'false'
+  " 2>&1 || true)"
+  [[ "$out" == *"Missing secrets blob"* ]]
+}
+it "dies with clear message when blob is missing" _t_decrypt_missing
+
+# ---------------------------------------------------------------------------
+describe "install.sh (Linux) — argument handling"
+# _NIXOS_BOOTSTRAP_NIX_SHELL=1 bypasses the nix-shell re-exec phase.
+
+_t_linux_rejects_unknown() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"; _common_stubs "$BIN"
+  mkdir -p "$T/target"
+  local out; out="$(PATH="$BIN:$PATH" HOME="$T" _NIXOS_BOOTSTRAP_NIX_SHELL=1 \
+    bash "$INSTALL_LINUX" --target "$T/target" --bogus 2>&1 || true)"
+  [[ "$out" == *"nknown argument"* ]]
+}
+it "rejects unknown flags" _t_linux_rejects_unknown
+
+_t_linux_dest_outside_target() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"; _common_stubs "$BIN"
+  mkdir -p "$T/target"
+  local out; out="$(PATH="$BIN:$PATH" HOME="$T" _NIXOS_BOOTSTRAP_NIX_SHELL=1 \
+    bash "$INSTALL_LINUX" --target "$T/target" --config-dest /tmp/outside --dry-run 2>&1 || true)"
+  [[ "$out" == *"not under"* ]]
+}
+it "rejects --config-dest outside --target" _t_linux_dest_outside_target
+
+_t_linux_dryrun() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"; _common_stubs "$BIN"
+  mkdir -p "$T/target/etc" "$T/target/home/rickie" "$T/target/var/lib/age"
+  local out; out="$(PATH="$BIN:$PATH" HOME="$T" GNUPGHOME="$T/.gnupg" \
+    _NIXOS_BOOTSTRAP_NIX_SHELL=1 \
+    bash "$INSTALL_LINUX" --target "$T/target" --host gibson --dry-run 2>&1 || true)"
+  [[ "$out" == *"next steps"* ]] || [[ "$out" == *"Next steps"* ]]
+}
+it "dry-run completes and shows next steps" _t_linux_dryrun
+
+_t_linux_age_path_in_summary() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"; _common_stubs "$BIN"
+  mkdir -p "$T/target"
+  local out; out="$(PATH="$BIN:$PATH" HOME="$T" _NIXOS_BOOTSTRAP_NIX_SHELL=1 \
+    bash "$INSTALL_LINUX" --target "$T/target" 2>&1 || true)"
+  [[ "$out" == *"var/lib/age"* ]]
+}
+it "summary shows Linux age key path (/var/lib/age)" _t_linux_age_path_in_summary
+
+# ---------------------------------------------------------------------------
+describe "install-darwin.sh — argument handling"
+# _DARWIN_BOOTSTRAP_NIX_SHELL=1 bypasses the nix-shell re-exec phase.
+
+_t_darwin_rejects_unknown() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local out; out="$(HOME="$T" _DARWIN_BOOTSTRAP_NIX_SHELL=1 \
+    bash "$INSTALL_DARWIN" --bogus 2>&1 || true)"
+  [[ "$out" == *"nknown argument"* ]]
+}
+it "rejects unknown flags" _t_darwin_rejects_unknown
+
+_t_darwin_default_host() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"; _common_stubs "$BIN"
+  local out; out="$(PATH="$BIN:$PATH" HOME="$T" GNUPGHOME="$T/.gnupg" \
+    _DARWIN_BOOTSTRAP_NIX_SHELL=1 \
+    bash "$INSTALL_DARWIN" --config-dest "$T/config" --dry-run 2>&1 || true)"
+  [[ "$out" == *"macbook"* ]]
+}
+it "defaults HOST to macbook" _t_darwin_default_host
+
+_t_darwin_age_path() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"; _common_stubs "$BIN"
+  local out; out="$(PATH="$BIN:$PATH" HOME="$T" GNUPGHOME="$T/.gnupg" \
+    _DARWIN_BOOTSTRAP_NIX_SHELL=1 \
+    bash "$INSTALL_DARWIN" --config-dest "$T/config" --dry-run 2>&1 || true)"
+  [[ "$out" == *"Library/Application Support/sops/age"* ]]
+}
+it "age key path matches mk-vars.nix isDarwin branch" _t_darwin_age_path
+
+_t_darwin_dryrun() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"; _common_stubs "$BIN"
+  local out; out="$(PATH="$BIN:$PATH" HOME="$T" GNUPGHOME="$T/.gnupg" \
+    _DARWIN_BOOTSTRAP_NIX_SHELL=1 \
+    bash "$INSTALL_DARWIN" --config-dest "$T/config" --dry-run 2>&1 || true)"
+  [[ "$out" == *"next steps"* ]] || [[ "$out" == *"Next steps"* ]]
+}
+it "dry-run completes and shows next steps" _t_darwin_dryrun
+
+_t_darwin_nix_run_cmd() {
+  local T; T="$(mktemp -d)"; trap "rm -rf '$T'" RETURN
+  local BIN="$T/bin"; mkdir -p "$BIN"; _common_stubs "$BIN"
+  # Provide a nix stub that records its arguments
+  printf '#!/usr/bin/env bash\necho "nix: $*"\n' > "$BIN/nix"; chmod +x "$BIN/nix"
+  # Use PATH="$BIN" only (no system PATH) so the real darwin-rebuild cannot be
+  # found — this forces the script into the first-time activation (nix run) branch.
+  # We still need bash and basic coreutils so add them explicitly.
+  local SAFE_PATH="$BIN:/usr/bin:/bin"
+  local out; out="$(PATH="$SAFE_PATH" HOME="$T" GNUPGHOME="$T/.gnupg" \
+    _DARWIN_BOOTSTRAP_NIX_SHELL=1 \
+    bash "$INSTALL_DARWIN" --config-dest "$T/config" --install 2>&1 || true)"
+  # Verify the correct first-time activation command was used
+  [[ "$out" == *"nix-darwin#darwin-rebuild"* ]]
+}
+it "first-time activation uses nix run nix-darwin#darwin-rebuild" _t_darwin_nix_run_cmd
+
+# ---------------------------------------------------------------------------
+echo
+echo "=== Bootstrap test suite ==="
+summary

--- a/bootstrap/test.sh
+++ b/bootstrap/test.sh
@@ -41,11 +41,11 @@ it() {
   if [[ -n "$FILTER" ]] && [[ "$name" != *"$FILTER"* ]]; then
     (( _SKIP++ )) || true; return
   fi
-  [[ $VERBOSE -eq 1 ]] && echo "  ▶ $name"
+  [[ $VERBOSE -eq 1 ]] && echo "  .... $name"
   if "$@" >/dev/null 2>&1; then
-    (( _PASS++ )) || true; echo "  ✅ $name"
+    (( _PASS++ )) || true; echo "  PASS: $name"
   else
-    (( _FAIL++ )) || true; echo "  ❌ $name"
+    (( _FAIL++ )) || true; echo "  FAIL: $name"
     "$@" 2>&1 | sed 's/^/      /' || true
   fi
 }
@@ -632,11 +632,10 @@ _t_darwin_nix_run_cmd() {
   local BIN="$T/bin"; mkdir -p "$BIN"; _common_stubs "$BIN"
   # Provide a nix stub that records its arguments
   printf '#!/usr/bin/env bash\necho "nix: $*"\n' > "$BIN/nix"; chmod +x "$BIN/nix"
-  # Use PATH="$BIN" only (no system PATH) so the real darwin-rebuild cannot be
-  # found — this forces the script into the first-time activation (nix run) branch.
-  # We still need bash and basic coreutils so add them explicitly.
-  local SAFE_PATH="$BIN:/usr/bin:/bin"
-  local out; out="$(PATH="$SAFE_PATH" HOME="$T" GNUPGHOME="$T/.gnupg" \
+  # Stub darwin-rebuild to exit 1 — install-darwin.sh checks with
+  # `darwin-rebuild --version` so a failing stub forces the nix run branch.
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$BIN/darwin-rebuild"; chmod +x "$BIN/darwin-rebuild"
+  local out; out="$(PATH="$BIN:$PATH" HOME="$T" GNUPGHOME="$T/.gnupg" \
     _DARWIN_BOOTSTRAP_NIX_SHELL=1 \
     bash "$INSTALL_DARWIN" --config-dest "$T/config" --install 2>&1 || true)"
   # Verify the correct first-time activation command was used

--- a/hosts/gibson/disko.nix
+++ b/hosts/gibson/disko.nix
@@ -2,75 +2,76 @@
   disk ? "/dev/vda",
   ...
 }:
-
 {
   disko.devices = {
     disk.main = {
       type = "disk";
-      # The disk can be overriden with disko-install using, e.g. "--disk main /dev/vga"
       device = disk;
-
       content = {
         type = "gpt";
-
         partitions = {
-
           ESP = {
             priority = 1;
             size = "1G";
             type = "EF00";
-
             content = {
               type = "filesystem";
               format = "vfat";
               mountpoint = "/boot";
               mountOptions = [ "umask=0077" ];
+              extraArgs = [
+                "-n"
+                "BOOT"
+              ];
             };
           };
-
-          luks = {
-            size = "100%";
-
+          SWAP = {
+            priority = 2;
+            size = "32G";
             content = {
               type = "luks";
-              name = "cryptroot";
-
-              askPassword = true;
-
+              name = "swap";
+              passwordFile = "/tmp/disko-luks-password";
+              extraFormatArgs = [
+                "--label"
+                "SWAP"
+              ];
               settings = {
                 allowDiscards = true;
               };
-
               content = {
-                type = "lvm_pv";
-                vg = "vg0";
+                type = "swap";
+                extraArgs = [
+                  "-L"
+                  "swap"
+                ];
               };
             };
           };
-        };
-      };
-    };
-
-    lvm_vg.vg0 = {
-      type = "lvm_vg";
-
-      lvs = {
-        swap = {
-          size = "32G";
-
-          content = {
-            type = "swap";
-            resumeDevice = true;
-          };
-        };
-
-        root = {
-          size = "100%FREE";
-
-          content = {
-            type = "filesystem";
-            format = "xfs";
-            mountpoint = "/";
+          ROOT = {
+            priority = 3;
+            size = "100%";
+            content = {
+              type = "luks";
+              name = "rootfs";
+              passwordFile = "/tmp/disko-luks-password";
+              extraFormatArgs = [
+                "--label"
+                "ROOT"
+              ];
+              settings = {
+                allowDiscards = true;
+              };
+              content = {
+                type = "filesystem";
+                format = "xfs";
+                mountpoint = "/";
+                extraArgs = [
+                  "-L"
+                  "rootfs"
+                ];
+              };
+            };
           };
         };
       };


### PR DESCRIPTION
Why: Bootstrap was Linux-only, lacked test coverage, and had an unreliable
disko partition layout that didn't match the actual system configuration. 

What:
- Split into common.sh, install.sh and install-darwin.sh with shared logic
- Add test suite covering shared functions and both install scripts
- Replace LVM-based disko layout (gibson) with two separate LUKS partitions
- Configures encryption via Disko, intially, with an on-disk passphrase file
- Uses luksChangeKey step to replace temporary password post-format
- Add correct filesystem labels to match hardware-configuration.nix

I've tested this on an external drive, via a NixOS 26.05 network boot image, and it all works.
I'll only know if theres problems on a proper rebuild.