### PR TITLE
fix(doomemacs): track upstream core/modules repo split

### DIFF
--- a/features/home/doomemacs/module.nix
+++ b/features/home/doomemacs/module.nix
@@ -69,8 +69,13 @@ mkMerge [
           --chmod=D2755,F744 ${rsyncChown} \
           ${inputs.doomemacs}/ "$EMACSDIR/"
 
+        mkdir -p "$EMACSDIR/sources/doom+"
+        ${pkgs.rsync}/bin/rsync -ogav --delete \
+          --chmod=D2755,F744 ${rsyncChown} \
+          ${inputs.doomemacs-modules}/ "$EMACSDIR/sources/doom+/"
+
         stamp="${config.xdg.stateHome}/doom/sync-stamp"
-        key="${emacsPkg}|${inputs.doomemacs}"
+        key="${emacsPkg}|${inputs.doomemacs}|${inputs.doomemacs-modules}"
 
         if [ ! -f "$stamp" ] || [ "$(cat "$stamp")" != "$key" ]; then
           echo "doom: inputs changed, running doom sync -u --force"

--- a/flake.lock
+++ b/flake.lock
@@ -63,16 +63,32 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1781423724,
-        "narHash": "sha256-oz+XeMjYgzcNq6r5VSzjb5VkEKhFdcj/rNROwxhDlFI=",
+        "lastModified": 1781777132,
+        "narHash": "sha256-ui3i68gfI70gbCHm3z6LGU/nLkhRZ65DNtp6zlQ1g+0=",
         "owner": "doomemacs",
-        "repo": "doomemacs",
-        "rev": "3806055a09a44243287a6ae9e7bd5a6cbe03dbbd",
+        "repo": "core",
+        "rev": "dce7f1d376cc21619cf161d288cc34512a211445",
         "type": "github"
       },
       "original": {
         "owner": "doomemacs",
-        "repo": "doomemacs",
+        "repo": "core",
+        "type": "github"
+      }
+    },
+    "doomemacs-modules": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781507079,
+        "narHash": "sha256-Ya4yEQ35bGEdDOVpitjJVzyUwvE/02UbiypiEW10rk0=",
+        "owner": "doomemacs",
+        "repo": "modules",
+        "rev": "8966104447d0a3131a232187bde148f58b32a322",
+        "type": "github"
+      },
+      "original": {
+        "owner": "doomemacs",
+        "repo": "modules",
         "type": "github"
       }
     },
@@ -676,6 +692,7 @@
         "claude-code-nix": "claude-code-nix",
         "disko": "disko",
         "doomemacs": "doomemacs",
+        "doomemacs-modules": "doomemacs-modules",
         "emacs-overlay": "emacs-overlay",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",

--- a/flake.nix
+++ b/flake.nix
@@ -38,8 +38,10 @@
     # Used as a Nix store path in features/home/doomemacs/module.nix for the
     # rsync-based activation script. The input hash drives the stamp-based
     # doom sync-skip logic — keeping as a flake input is intentional.
-    doomemacs.url = "github:doomemacs/doomemacs";
+    doomemacs.url = "github:doomemacs/core";
     doomemacs.flake = false;
+    doomemacs-modules.url = "github:doomemacs/modules";
+    doomemacs-modules.flake = false;
 
     # Used as a store path in features/home/symlinks/module.nix to symlink the
     # Dracula theme into ~/.qutebrowser and ~/.config/qutebrowser. Keeping as a


### PR DESCRIPTION
Why: Doom Emacs split its monorepo into separate `doomemacs/core` and `doomemacs/modules` repositories; the single `doomemacs/doomemacs` input no longer reflects upstream structure.

What:
- Switch `doomemacs` flake input from `doomemacs/doomemacs` → `doomemacs/core`
- Add `doomemacs-modules` flake input pointing to `doomemacs/modules`
- Rsync modules into `$EMACSDIR/sources/doom+/` alongside core during activation
- Include modules input hash in the stamp key so `doom sync` reruns on module updates

Notes: Both inputs are kept as non-flake store paths so the stamp-based sync-skip logic continues to work correctly; the key now covers both input hashes.
