### PR TITLE
refactor(zsh): improve gc commit helper template output

### DIFF
--- a/features/home/core/zsh.nix
+++ b/features/home/core/zsh.nix
@@ -19,11 +19,12 @@ _: {
         msg=$(printf 'Staged files:\n%s\n\nDiff:\n%s' \
           "$(git diff --cached --stat)" \
           "$(git diff --cached)" \
-          | claude -p "Suggest a commit message for these changes. Follow this template, replacing placeholder lines. Output the filled message as plain text — use markdown code fences only for code snippets or references, not for the commit message itself. Do NOT use # comment prefixes on the Why/What/Notes lines, only strip the comment lines from the template itself. Output the commit related context only, in line with the template strucutre, no preamble or explanation before it:\n\n''${template}")
-        tmpfile=$(mktemp /tmp/COMMIT_EDITMSG.XXXXXX)
-        printf '%s\n\n%s\n' "$msg" "$template" >> "$tmpfile"
-        git commit -e -t "$tmpfile"
-        rm -f "$tmpfile"
+          | claude -p "Suggest a commit message for these changes. Follow this template, replacing placeholder lines. Output the filled message as plain text — use markdown code fences only for code snippets or references, not for the commit message itself. Do NOT use # comment prefixes on the Why/What/Notes lines, only strip the comment lines from the template itself. Output the commit related context only, in line with the template structure, no preamble or explanation before it:\n\n''${template}")
+          tmpfile=$(mktemp /tmp/COMMIT_EDITMSG.XXXXXX)
+          printf '%s\n\n# Template reference:\n%s\n' "$msg" \
+            "$(sed 's/^/# /' <<< "$template")" > "$tmpfile"
+          git commit -e -F "$tmpfile"
+          rm -f "$tmpfile"
       }
     '';
 


### PR DESCRIPTION
Why: The template reference was being appended with `>>` instead of `>`, and the template lines weren't prefixed as comments, risking them being included in the commit message. The `-t` flag also caused git to append a duplicate template.

What:
- Switch from `-t` to `-F` so git uses the file as the full message without appending template boilerplate
- Prefix template reference lines with `#` via `sed` so they appear as comments in the editor
- Replace `>>` with `>` to avoid double-writing the tmpfile
- Fix typo: "strucutre" → "structure" in the claude prompt
