### PR TITLE
fix(gibson): pin hyprland, harden pcscd, and misc stability fixes

### DIFF
--- a/hosts/gibson/applications/hypr/hyprland.lua
+++ b/hosts/gibson/applications/hypr/hyprland.lua
@@ -155,6 +155,7 @@ return function(WS)
   hl.window_rule({ match = { class = "^(explorer.exe)$" }, move = { 1945, 1072 }, workspace = "name:" .. WS.WS3 })
   hl.window_rule({ match = { class = "^(gamescope)$" }, no_blur = true, workspace = "name:" .. WS.WS3 })
   hl.window_rule({ match = { title = "^(007 First Light)$" }, no_blur = true, workspace = "name:" .. WS.WS3 })
+  hl.window_rule({ match = { class = "^(steam_app_0)$" }, no_blur = true, workspace = "name:" .. WS.WS3 })
 
   hl.window_rule({ match = { class = "^(spicy)$" }, workspace = "name:" .. WS.WS4, fullscreen = true, idle_inhibit = "fullscreen" })
   hl.window_rule({ match = { class = "^(virt-manager)$" }, workspace = "name:" .. WS.WS4, float = true, center = true, size = { 970, 560 } })

--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -49,6 +49,7 @@ in
       "zswap.compressor=lz4"
       "zswap.max_pool_percent=20"
       "zswap.shrinker_enabled=1"
+      "pcie_aspm=off"
     ];
     extraModulePackages = [ ];
     loader = {

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -92,7 +92,23 @@
           "-Dcava=disabled"
         ];
         doInstallCheck = false;
+        doCheck = false;
+        nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.catch2_3 ];
       });
+
+      # TODO: Monitor new hyprland package releases
+      # This is currently propagating upstream through Hydra into nixos-unstable
+      hyprland = prev.hyprland.overrideAttrs (old: {
+        version = "0.55.4";
+        src = old.src.override {
+          tag = "v0.55.4";
+          hash = "sha256-IuT0HnOr/0rAw+GXr+OwWx89FjA4Og1FqP7vywEwRJM=";
+        };
+      });
+      xdg-desktop-portal-hyprland = prev.xdg-desktop-portal-hyprland.override {
+
+        inherit (final) hyprland; # uses the overridden version above
+      };
     })
 
     inputs.self.overlays.default

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -103,7 +103,7 @@ in
       ];
     };
     services = {
-      "nix-daemon" = {
+      nix-daemon = {
         environment = {
           TMPDIR = "/nix/tmp";
         };
@@ -116,6 +116,20 @@ in
           config.environment.etc."nix/nix.conf".source
         ];
         after = [ "local-fs.target" ];
+      };
+      pcscd = {
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig.Restart = "always";
+      };
+      pcscd-resume = {
+        description = "Restart pcscd after hibernate resume";
+        wantedBy = [ "post-resume.target" ];
+        after = [ "post-resume.target" ];
+        script = ''
+          sleep 3
+          ${pkgs.systemd}/bin/systemctl restart pcscd
+        '';
+        serviceConfig.Type = "oneshot";
       };
     };
   };
@@ -238,7 +252,11 @@ in
       };
     };
 
-    pcscd.enable = true;
+    pcscd = {
+      enable = true;
+      plugins = [ pkgs.ccid ];
+    };
+
     upower.enable = true;
 
     dbus = {


### PR DESCRIPTION
Why: hyprland 0.55.4 hasn't propagated through Hydra to nixos-unstable yet; pcscd was unreliable after hibernate resume; PCIe ASPM causing hardware instability

What:
- Pin hyprland to v0.55.4 via overlay with matching xdg-desktop-portal-hyprland
- Add pcscd Restart=always and a post-resume oneshot to recover after hibernate
- Add ccid plugin to pcscd service for smartcard reader support
- Add pcie_aspm=off kernel param to fix PCIe stability issues
- Add steam_app_0 window rule (no blur, routed to gaming workspace)

Notes: Remove hyprland overlay once v0.55.4 lands in nixos-unstable — TODO left in overlays/default.nix as a reminder
