### PR TITLE
fix(obs-studio): add obs-backgroundremoval plugin

### DIFF
--- a/features/home/obs-studio/module.nix
+++ b/features/home/obs-studio/module.nix
@@ -11,6 +11,7 @@
       obs-studio-plugins.obs-scale-to-sound
       obs-studio-plugins.obs-vkcapture
       obs-studio-plugins.obs-gstreamer
+      obs-studio-plugins.obs-backgroundremoval
     ];
   };
 


### PR DESCRIPTION
Why: To play around with camera background removal in OBS!

What:
- Add obs-backgroundremoval to the OBS Studio plugins list
