### PR TITLE
feat(overlays): add automated obsolescence audit for temporary overlays

### DIFF
--- a/.github/workflows/audit-overlays.yaml
+++ b/.github/workflows/audit-overlays.yaml
@@ -1,0 +1,316 @@
+name: Audit temporary overlays
+
+on:
+  # Run after the weekly flake lock update so nix eval reflects freshest nixpkgs
+  workflow_run:
+    workflows: ["Update flake.lock"]
+    types: [completed]
+  # Allow manual trigger for ad-hoc checks
+  workflow_dispatch: {}
+
+jobs:
+  audit:
+    name: Check overlay obsolescence
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+
+      - name: Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      # Required for private flake inputs (nix-secrets etc.) during nix eval
+      - name: Start ssh-agent and add deploy read-only key
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.CI_GITHUB_SSH_KEY }}
+
+      - name: Add GitHub to known_hosts
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Force git to use known_hosts
+        run: |
+          echo "GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts" >> "$GITHUB_ENV"
+
+      - name: Run overlay audit
+        id: audit
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+        run: |
+          set -euo pipefail
+
+          OBSOLETE_IDS=()
+          REPORT_LINES=()
+
+          # ----------------------------------------------------------------
+          # version_gte: returns 0 if $1 >= $2, 1 otherwise.
+          # Uses GNU sort -V (coreutils, available on ubuntu-latest).
+          # Handles dot-separated version strings including NVIDIA-style
+          # three-component versions (610.43.02).
+          # ----------------------------------------------------------------
+          version_gte() {
+            local a="$1" b="$2"
+            [ "$(printf '%s\n%s' "$a" "$b" | sort -V | head -n1)" = "$b" ]
+          }
+
+          # ----------------------------------------------------------------
+          # check_nixpkgs_version: evaluates nixpkgs#legacyPackages.<system>.<attr>
+          # and compares against threshold.
+          # Returns: 0 = obsolete, 1 = still needed, 2 = eval failed
+          # Prints the resolved current version to stdout on success.
+          # ----------------------------------------------------------------
+          check_nixpkgs_version() {
+            local attr="$1" threshold="$2" system="$3"
+            local current
+
+            echo "    nix eval nixpkgs#legacyPackages.${system}.${attr} ..." >&2
+            current=$(nix eval --raw "nixpkgs#legacyPackages.${system}.${attr}" 2>/dev/null) || {
+              echo "    WARNING: eval failed" >&2
+              return 2
+            }
+            echo "    result: ${current}  (threshold: ${threshold})" >&2
+            echo "$current"
+            version_gte "$current" "$threshold"
+          }
+
+          # ----------------------------------------------------------------
+          # check_github_items: checks state of issues or PRs via REST API.
+          # item_type: "issue" or "pull"
+          # Prints one summary line per item to stdout (captured by caller).
+          # Returns: 0 if ALL items are resolved, 1 otherwise.
+          #
+          # BACKLINK PREVENTION:
+          # - Progress lines go to stderr only (never reach PR body)
+          # - Summary lines use redirect.github.com instead of github.com —
+          #   GitHub's documented mechanism for suppressing cross-repo backlinks:
+          #   docs.github.com/en/get-started/writing-on-github/
+          #   working-with-advanced-formatting/autolinked-references-and-urls
+          # - Link text uses plain words, never owner/repo#number syntax
+          # ----------------------------------------------------------------
+          check_github_items() {
+            local items_json="$1" item_type="$2"
+            local all_done=true
+
+            while IFS= read -r item; do
+              local repo number state merged api_response repo_short
+
+              repo=$(echo "$item" | jq -r '.repo')
+              number=$(echo "$item" | jq -r '.number')
+              repo_short="${repo##*/}"
+
+              echo "    Checking ${repo} ${item_type} ${number} ..." >&2
+              api_response=$(curl -fsSL \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${GH_TOKEN}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/${repo}/${item_type}s/${number}")
+
+              if [ "$item_type" = "pull" ]; then
+                merged=$(echo "$api_response" | jq -r '.merged')
+                state=$([ "$merged" = "true" ] && echo "merged" || echo "$(echo "$api_response" | jq -r '.state')")
+              else
+                state=$(echo "$api_response" | jq -r '.state')
+              fi
+
+              echo "    state: ${state}" >&2
+
+              # stdout only — this line is captured into REPORT_LINES via $()
+              # Uses redirect.github.com (no backlink) and plain link text (no owner/repo#N)
+              echo "[${repo_short} ${item_type} ${number}](https://redirect.github.com/${repo}/${item_type}s/${number}): \`${state}\`"
+
+              if [ "$item_type" = "pull" ] && [ "$state" != "merged" ]; then
+                all_done=false
+              elif [ "$item_type" = "issue" ] && [ "$state" != "closed" ]; then
+                all_done=false
+              fi
+            done < <(echo "$items_json" | jq -c '.[]')
+
+            [ "$all_done" = true ]
+          }
+
+          # ----------------------------------------------------------------
+          # Main loop — read audit metadata from flake output.
+          # Uses process substitution throughout to keep OBSOLETE_IDS and
+          # REPORT_LINES in the current shell (pipe-into-while runs a subshell
+          # and would silently discard all accumulated values).
+          # ----------------------------------------------------------------
+          echo "Evaluating flake.overlayAudits ..."
+          AUDIT_JSON=$(nix eval .#overlayAudits --json)
+
+          while IFS= read -r host_key; do
+            echo ""
+            echo "=== ${host_key} ==="
+
+            while IFS= read -r id; do
+              entry=$(echo "$AUDIT_JSON" | jq -c --arg h "$host_key" --arg id "$id" '.[$h][$id]')
+              strategy=$(echo "$entry" | jq -r '.strategy')
+              description=$(echo "$entry" | jq -r '.description')
+              notes=$(echo "$entry" | jq -r '.notes // empty')
+
+              echo ""
+              echo "  [${id}] ${strategy}: ${description}"
+
+              is_obsolete=false
+
+              case "$strategy" in
+                nixpkgs-version)
+                  attr=$(echo "$entry" | jq -r '.attr')
+                  threshold=$(echo "$entry" | jq -r '.threshold')
+                  all_met=true
+                  version_lines=()
+
+                  while IFS= read -r system; do
+                    current=""
+                    rc=0
+                    current=$(check_nixpkgs_version "$attr" "$threshold" "$system") || rc=$?
+
+                    case $rc in
+                      0) version_lines+=("- ✅ \`${system}\`: \`${attr} = ${current}\` >= \`${threshold}\`") ;;
+                      1) version_lines+=("- ⏳ \`${system}\`: \`${attr} = ${current}\` < \`${threshold}\`")
+                         all_met=false ;;
+                      2) version_lines+=("- ⚠️  \`${system}\`: eval of \`${attr}\` failed — manual check required")
+                         all_met=false ;;
+                    esac
+                  done < <(echo "$entry" | jq -r '.systems[]')
+
+                  if [ "$all_met" = true ]; then
+                    is_obsolete=true
+                    REPORT_LINES+=("✅ **${host_key} / ${id}**: nixpkgs meets threshold \`>= ${threshold}\` on all declared systems")
+                  else
+                    REPORT_LINES+=("⏳ **${host_key} / ${id}**: threshold \`${threshold}\` not yet reached on all systems")
+                  fi
+                  for line in "${version_lines[@]}"; do
+                    REPORT_LINES+=("$line")
+                  done
+                  ;;
+
+                nixpkgs-issue)
+                  items_json=$(echo "$entry" | jq -c '.trackingIssues')
+                  issue_output=""
+                  rc=0
+                  issue_output=$(check_github_items "$items_json" "issue") || rc=$?
+                  summary=$(echo "$issue_output" | paste -sd ', ')
+                  if [ $rc -eq 0 ]; then
+                    is_obsolete=true
+                    REPORT_LINES+=("✅ **${host_key} / ${id}**: all tracking issues closed — ${summary}")
+                  else
+                    REPORT_LINES+=("⏳ **${host_key} / ${id}**: tracking issue(s) still open — ${summary}")
+                  fi
+                  ;;
+
+                nixpkgs-pr)
+                  items_json=$(echo "$entry" | jq -c '.trackingPRs')
+                  pr_output=""
+                  rc=0
+                  pr_output=$(check_github_items "$items_json" "pull") || rc=$?
+                  summary=$(echo "$pr_output" | paste -sd ', ')
+                  if [ $rc -eq 0 ]; then
+                    is_obsolete=true
+                    REPORT_LINES+=("✅ **${host_key} / ${id}**: all tracking PRs merged — ${summary}")
+                  else
+                    REPORT_LINES+=("⏳ **${host_key} / ${id}**: tracking PR(s) not yet merged — ${summary}")
+                  fi
+                  ;;
+
+                *)
+                  echo "  WARNING: unknown strategy '${strategy}'"
+                  REPORT_LINES+=("⚠️  **${host_key} / ${id}**: unknown strategy \`${strategy}\` — update audit.nix")
+                  ;;
+              esac
+
+              if [ "$is_obsolete" = true ]; then
+                OBSOLETE_IDS+=("${host_key}::${id}")
+                if [ -n "$notes" ]; then
+                  REPORT_LINES+=("  📎 **Note:** ${notes}")
+                fi
+              fi
+              # Blank line between overlay entries for Markdown paragraph separation
+              REPORT_LINES+=("")
+
+            done < <(echo "$AUDIT_JSON" | jq -r --arg h "$host_key" '.[$h] | keys[]')
+          done < <(echo "$AUDIT_JSON" | jq -r 'keys[]')
+
+          # ----------------------------------------------------------------
+          # Emit outputs
+          # ----------------------------------------------------------------
+          echo ""
+          echo "Obsolete: ${OBSOLETE_IDS[*]:-none}"
+
+          REPORT_FILE="$(mktemp)"
+          printf '%s\n' "${REPORT_LINES[@]}" > "$REPORT_FILE"
+
+          {
+            echo "obsolete_count=${#OBSOLETE_IDS[@]}"
+            echo "obsolete_ids=${OBSOLETE_IDS[*]:-}"
+            echo "report_file=${REPORT_FILE}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open issue for obsolete overlays
+        if: steps.audit.outputs.obsolete_count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+        run: |
+          set -euo pipefail
+
+          REPORT_FILE="${{ steps.audit.outputs.report_file }}"
+
+          # Check whether an open audit issue already exists to avoid duplicates.
+          # Matches on title prefix so re-runs on the same day don't open a second issue.
+          existing=$(gh issue list \
+            --label "automated" \
+            --state open \
+            --json number,title \
+            --jq '.[] | select(.title | startswith("chore(overlays): audit")) | .number' \
+            2>/dev/null | head -n1 || true)
+
+          if [ -n "$existing" ]; then
+            echo "Open audit issue already exists (#${existing}) — skipping"
+            exit 0
+          fi
+
+          # ----------------------------------------------------------------
+          # Build issue body.
+          # Backlink audit:
+          # - No owner/repo#number patterns anywhere in static strings
+          # - REPORT_FILE content uses redirect.github.com for all external
+          #   links and plain link text (no owner/repo#N syntax)
+          # - ${{ github.repository }} is our own repo — no external backlink
+          # ----------------------------------------------------------------
+          ISSUE_BODY_FILE="$(mktemp)"
+          {
+            printf '## Overlay audit — %s\n\n' "$(date -u +'%Y-%m-%d')"
+            printf 'The automated overlay audit detected **%s** overlay(s) that appear to be obsolete based on current nixpkgs state.\n\n' "${{ steps.audit.outputs.obsolete_count }}"
+            printf '### Results\n\n'
+            cat "$REPORT_FILE"
+            printf '\n### What to do\n\n'
+            printf 'For each ✅ entry above:\n\n'
+            printf -- '- Remove the overlay block from `overlays/default.nix` in the relevant host directory\n'
+            printf -- '- Remove the corresponding entry from `overlays/audit.nix` in the same directory\n'
+            printf -- '- Action any coupled removals described in the 📎 notes above\n'
+            printf -- '- Run `nixos-rebuild build --flake .#gibson` and/or `darwin-rebuild build --flake .#macbook` locally to confirm clean build\n'
+            printf -- '- Raise a PR linked to this issue and merge\n'
+            printf -- '- Close this issue once all flagged overlays have been removed\n'
+            printf '\n---\n*Generated by [audit-overlays workflow](https://github.com/%s/actions/workflows/audit-overlays.yaml)*\n' "${{ github.repository }}"
+          } > "$ISSUE_BODY_FILE"
+
+          gh issue create \
+            --title "chore(overlays): audit flagged obsolete overlays ($(date -u +'%d/%m/%y'))" \
+            --body-file "$ISSUE_BODY_FILE" \
+            --label "dependencies,automated"
+
+          echo "Issue created"
+
+      - name: No obsolete overlays found
+        if: steps.audit.outputs.obsolete_count == '0'
+        run: |
+          echo "All audited overlays are still required. No PR needed."
+          cat "${{ steps.audit.outputs.report_file }}"

--- a/flake/parts/exports/overlay-audits.nix
+++ b/flake/parts/exports/overlay-audits.nix
@@ -1,0 +1,113 @@
+{ lib, config, ... }:
+let
+  inherit (config.repo) hosts;
+
+  # Read audit.nix from a host's overlays directory if it exists.
+  # host.overlaysModule is the directory path (e.g. hosts/gibson/overlays),
+  # so we append /audit.nix to get the sibling file.
+  readHostAudits =
+    host:
+    let
+      auditFile = host.overlaysModule + "/audit.nix";
+    in
+    if builtins.pathExists auditFile then import auditFile else { };
+
+  # Aggregate per-host audit metadata across all hosts.
+  # Keyed by hostname so the CI script can report which host each overlay belongs to.
+  hostAudits = lib.mapAttrs (_name: readHostAudits) hosts;
+
+  # Hook for the system-wide overlay at features/system/core/overlays.nix.
+  # This file is imported transitively via systemProfiles and is not reachable
+  # through host.overlaysModule. Wire it explicitly here so it gets the same
+  # treatment when populated.
+  systemAuditFile = ./../../../features/system/core/overlays/audit.nix;
+  systemAudits =
+    if builtins.pathExists systemAuditFile then
+      { "features/system/core/overlays" = import systemAuditFile; }
+    else
+      { };
+
+in
+{
+  options.flake.overlayAudits = lib.mkOption {
+    type = lib.types.attrsOf (
+      lib.types.attrsOf (
+        lib.types.submodule {
+          options = {
+            strategy = lib.mkOption {
+              type = lib.types.enum [
+                "nixpkgs-version"
+                "nixpkgs-issue"
+                "nixpkgs-pr"
+              ];
+              description = "Detection strategy for overlay obsolescence.";
+            };
+
+            description = lib.mkOption {
+              type = lib.types.str;
+              description = "Human-readable description of what this overlay does and why.";
+            };
+
+            systems = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              description = "Systems this overlay applies to. Scopes nix eval to the correct platform.";
+            };
+
+            attr = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "nixpkgs legacyPackages attribute path for version eval (nixpkgs-version only).";
+            };
+
+            threshold = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "Minimum version for the overlay to be considered obsolete (nixpkgs-version only).";
+            };
+
+            trackingIssues = lib.mkOption {
+              type = lib.types.listOf (
+                lib.types.submodule {
+                  options = {
+                    repo = lib.mkOption { type = lib.types.str; };
+                    number = lib.mkOption { type = lib.types.int; };
+                  };
+                }
+              );
+              default = [ ];
+              description = "GitHub issues that must ALL be closed (nixpkgs-issue only).";
+            };
+
+            trackingPRs = lib.mkOption {
+              type = lib.types.listOf (
+                lib.types.submodule {
+                  options = {
+                    repo = lib.mkOption { type = lib.types.str; };
+                    number = lib.mkOption { type = lib.types.int; };
+                  };
+                }
+              );
+              default = [ ];
+              description = "GitHub PRs that must ALL be merged (nixpkgs-pr only).";
+            };
+
+            notes = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "Reviewer notes: coupled removals, related files, context.";
+            };
+          };
+        }
+      )
+    );
+    default = { };
+    description = ''
+      Audit metadata for temporary overlays, aggregated from each host's
+      overlays/audit.nix and features/system/core/overlays/audit.nix.
+      Keyed by hostname (or system path), then by overlay id.
+      Consumed by the audit-overlays CI workflow via `nix eval .#overlayAudits --json`.
+    '';
+  };
+
+  config.flake.overlayAudits = hostAudits // systemAudits;
+}

--- a/hosts/gibson/overlays/audit.nix
+++ b/hosts/gibson/overlays/audit.nix
@@ -1,0 +1,70 @@
+# Audit metadata for temporary overlays — managed by flake/parts/exports/overlay-audits.nix
+# Do not use owner/repo#number syntax anywhere in this file — see audit-overlays.yaml for why.
+{
+  bitwarden-desktop = {
+    description = "Override electron_39 with electron_39-bin to unblock bitwarden-desktop build";
+    notes = "Also remove permittedInsecurePackages entry from hosts/gibson/system.nix.";
+    strategy = "nixpkgs-issue";
+    systems = [ "x86_64-linux" ];
+    trackingIssues = [
+      {
+        number = 526914;
+        repo = "NixOS/nixpkgs";
+      }
+    ];
+  };
+
+  hyprland = {
+    attr = "hyprland.version";
+    description = "Pin hyprland to 0.55.4 while nixpkgs-unstable propagates via Hydra";
+    notes = "xdg-desktop-portal-hyprland override is a coupled removal — remove both blocks together.";
+    strategy = "nixpkgs-version";
+    systems = [ "x86_64-linux" ];
+    threshold = "0.55.4";
+  };
+
+  lutris = {
+    description = "Disable openldap doCheck inside lutris FHS env to unblock builds";
+    notes = "Both issues must be closed before removing this overlay.";
+    strategy = "nixpkgs-issue";
+    systems = [ "x86_64-linux" ];
+    trackingIssues = [
+      {
+        number = 513245;
+        repo = "NixOS/nixpkgs";
+      }
+      {
+        number = 514113;
+        repo = "NixOS/nixpkgs";
+      }
+    ];
+  };
+
+  mpv-unwrapped = {
+    attr = "mpv-unwrapped.version";
+    description = "Backport fence-sync fix milestoned for mpv 0.42.0";
+    notes = "mpv override is a coupled removal — remove both blocks together.";
+    strategy = "nixpkgs-version";
+    systems = [ "x86_64-linux" ];
+    threshold = "0.42.0";
+  };
+
+  waybar = {
+    attr = "waybar.version";
+    description = "Pin waybar to git-0594574 pending next tagged release";
+    notes = "Also remove waybar-patched flake input from flake.nix. Release cadence has been strictly minor bumps since 0.11.0.";
+    strategy = "nixpkgs-version";
+    systems = [ "x86_64-linux" ];
+    threshold = "0.16.0";
+  };
+
+  nvidia-modprobe = {
+    strategy = "nixpkgs-version";
+    description = "Keep nvidia-modprobe in sync with pinned driver 610.43.02";
+    systems = [ "x86_64-linux" ];
+    attr = "linuxPackages.nvidiaPackages.new_feature.version";
+    threshold = "610.43.02";
+    notes = "COUPLED REMOVAL: hosts/gibson/hardware-configuration.nix mkDriver block for nvidia610 must also be removed. Both pin driver version 610.43.02.";
+  };
+
+}

--- a/hosts/macbook/overlays/audit.nix
+++ b/hosts/macbook/overlays/audit.nix
@@ -1,0 +1,18 @@
+# Audit metadata for temporary overlays in hosts/macbook/overlays/default.nix.
+# Each key must match the overlay identifier used in default.nix.
+# Read by flake/parts/exports/overlay-audits.nix and consumed by the
+# audit-overlays CI workflow. See flake.overlayAudits for option definitions.
+{
+  qtwebengine = {
+    strategy = "nixpkgs-pr";
+    description = "Darwin qt6.qtwebengine build fix, pending upstream PR merge";
+    systems = [ "aarch64-darwin" ];
+    trackingPRs = [
+      {
+        repo = "NixOS/nixpkgs";
+        number = 515997;
+      }
+    ];
+    notes = "COUPLED REMOVAL: also remove qtwebengine-fix flake input from flake.nix and the qtPinnedPkgs let-binding in hosts/macbook/overlays/default.nix.";
+  };
+}


### PR DESCRIPTION
Why: Temporary overlays accumulate silently — there was no mechanism to
detect when upstream nixpkgs had caught up and a pinned overlay could
safely be removed.

What:
- Add `flake.overlayAudits` output aggregating per-host audit metadata
from each host's `overlays/audit.nix`
- Add `audit.nix` for gibson (6 overlays: hyprland, mpv, waybar,
nvidia-modprobe, bitwarden-desktop, lutris) and macbook (qtwebengine)
with strategy/threshold/tracking metadata
- Add `audit-overlays` CI workflow that runs after `Update flake.lock`,
evaluates each overlay via nixpkgs-version/nixpkgs-issue/nixpkgs-pr
strategies, and opens an issue when obsolete overlays are detected

Notes: A `features/system/core/overlays/audit.nix` hook is wired in the
exporter but the file does not yet exist — it will be silently skipped
until created.
