### PR TITLE
fix(doomemacs): add empty cli.el stub

### DIFF
--- a/features/home/doomemacs/doom/cli.el
+++ b/features/home/doomemacs/doom/cli.el
@@ -1,0 +1,1 @@
+;;; cli.el -*- lexical-binding: t; -*-


### PR DESCRIPTION
Why: Doom Emacs v2.2.0 expects a cli.el file alongside
config.el/init.el/packages.el for CLI-level customization; its absence
left the module set incomplete and caused further build failure

What:
- Add features/home/doomemacs/doom/cli.el with standard lexical-binding header, no logic yet
