### PR TITLE
chore(gibson): drop obsolete nvidia 610 pin and lutris overlay

### DIFF
--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -9,17 +9,7 @@
   vars,
   ...
 }:
-let
-  nvidia610 = config.boot.kernelPackages.nvidiaPackages.mkDriver {
-    version = "610.43.02";
 
-    sha256_64bit = "sha256-MDSgVLtM33dS/43CclZMsQVROAS/9TU4lFkBsWyndGM=";
-    sha256_aarch64 = "sha256-isWTnokUA/dzWocFBLalnk4+O5gSExVjs3dVpdYTU88=";
-    openSha256 = "sha256-hP5NVZZ4vGsACHLmUDKq4uckpd/kn1GxCSYnnJfAuBs=";
-    settingsSha256 = "sha256-0YAhufRgjDW+uR+kjaTb154fibpcDw8QowfrucoZsKE=";
-    persistencedSha256 = "sha256-Whgv9X+v2fRhzliOl2LzltY9v1SxDafFfv3IUPqj/hk=";
-  };
-in
 {
   imports = [
     (modulesPath + "/installer/scan/not-detected.nix")
@@ -139,14 +129,7 @@ in
       open = true;
       powerManagement.enable = true;
       nvidiaSettings = true;
-      #package = config.boot.kernelPackages.nvidiaPackages.stable;
-      package = nvidia610.overrideAttrs (old: {
-        postInstall = (if old.postInstall or null == null then "" else old.postInstall) + ''
-          if [ -n "''${firmware:-}" ] && [ -d firmware ]; then
-            install -Dm644 -t "$firmware/lib/firmware/nvidia/$version" firmware/*.bin
-          fi
-        '';
-      });
+      package = config.boot.kernelPackages.nvidiaPackages.latest;
     };
   };
 

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -37,45 +37,6 @@
         inherit (final) mpv-unwrapped;
       };
 
-      # TODO(upstream): remove once upstream has a fix
-      # https://github.com/NixOS/nixpkgs/issues/513245 - Build failure: lutris-free
-      # https://github.com/NixOS/nixpkgs/issues/514113 - pkgsi686Linux.openldap: test checks won't let it compile on x86_64
-      # Context: Prevents build test failures in OpenLDAP as required by Lutris
-      lutris = prev.lutris.override {
-        # Intercept buildFHSEnv to modify target packages
-        buildFHSEnv =
-          args:
-          pkgs.buildFHSEnv (
-            args
-            // {
-              multiPkgs =
-                envPkgs:
-                let
-                  # Fetch original package list
-                  originalPkgs = args.multiPkgs envPkgs;
-
-                  # Disable tests for openldap
-                  customLdap = envPkgs.openldap.overrideAttrs (_: {
-                    doCheck = false;
-                  });
-                in
-                # Replace broken openldap with the custom one
-                builtins.filter (p: (p.pname or "") != "openldap") originalPkgs ++ [ customLdap ];
-            }
-          );
-      };
-
-      nvidia-modprobe = prev.nvidia-modprobe.overrideAttrs (_old: {
-        version = "610.43.02";
-
-        src = final.fetchFromGitHub {
-          owner = "NVIDIA";
-          repo = "nvidia-modprobe";
-          rev = "610.43.02";
-          hash = "sha256-4FzxZR85mWvqUh3FNNlzsg1b7yeMCXuVHMII4AeP8RA=";
-        };
-      });
-
       # upstream nixpkgs issue - remove when bitwarden-desktop bumps electron
       # TODO: Monitor this for upstream: https://github.com/NixOS/nixpkgs/issues/526914
       # Also remove permittedInsecurePackages from hosts/gibson/system.nix


### PR DESCRIPTION
Why: Custom nvidia 610.43.02 driver build, its matching nvidia-modprobe overlay, and the lutris/openldap test-disable workaround are no longer needed now that upstream nixpkgs provides a working `nvidiaPackages.latest` and the underlying lutris/openldap build issues are resolved upstream.

What:
- Removed the `nvidia610` custom driver derivation from hardware-configuration.nix and switched back to `config.boot.kernelPackages.nvidiaPackages.latest`
- Removed the `lutris` openldap-test-disable override and the `nvidia-modprobe` version-pin overlay from overlays/default.nix

Notes: Resolves #208
