### PR TITLE
feat(overlays): validate audit.nix structure at eval-time and pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -168,14 +168,35 @@ check_overlay_audit_consistency() {
 }
 
 overlay_errors=false
+audit_nix_staged=false
+
 for f in "${staged_nix_files[@]}"; do
   case "$f" in
     */overlays/default.nix)
       echo "Checking overlay audit consistency: ${f}"
       check_overlay_audit_consistency "$f" || overlay_errors=true
       ;;
+    */overlays/audit.nix)
+      audit_nix_staged=true
+      ;;
   esac
 done
+
+# If any audit.nix was staged, validate the full overlayAudits flake output.
+# This catches missing required fields per strategy and type errors via the
+# module system assertions in flake/parts/exports/overlay-audits.nix.
+if [ "$audit_nix_staged" = true ]; then
+  echo "Validating flake.overlayAudits (audit.nix staged) ..."
+  if ! nix eval .#overlayAudits --json > /dev/null 2>&1; then
+    echo ""
+    echo "flake.overlayAudits eval failed — audit.nix has invalid or missing fields."
+    echo "Run: nix eval .#overlayAudits --json"
+    echo "to see the full error."
+    overlay_errors=true
+  else
+    echo "  flake.overlayAudits: valid ✓"
+  fi
+fi
 
 if [ "$overlay_errors" = true ]; then
   exit 1

--- a/.github/workflows/audit-overlays.yaml
+++ b/.github/workflows/audit-overlays.yaml
@@ -163,7 +163,12 @@ jobs:
 
               case "$strategy" in
                 nixpkgs-version)
-                  attr=$(echo "$entry" | jq -r '.attr')
+                  attr=$(echo "$entry" | jq -r '.attr // empty')
+                  # Default attr to <id>.version when not explicitly set
+                  if [ -z "$attr" ]; then
+                    attr="${id}.version"
+                    echo "    attr not set — defaulting to ${attr}"
+                  fi
                   threshold=$(echo "$entry" | jq -r '.threshold')
                   all_met=true
                   version_lines=()

--- a/flake/parts/exports/overlay-audits.nix
+++ b/flake/parts/exports/overlay-audits.nix
@@ -2,19 +2,55 @@
 let
   inherit (config.repo) hosts;
 
+  # Validate strategy-specific required fields at eval time.
+  # This means `nix eval .#overlayAudits` fails loudly with a clear message
+  # if an audit.nix entry is structurally wrong, rather than silently producing
+  # a bad result that only surfaces when CI runs.
+  validateEntry =
+    hostKey: id: entry:
+    let
+      inherit (entry) strategy;
+      loc = "${hostKey} / ${id}";
+
+      assertVersionFields = lib.assertMsg (
+        entry.threshold != null
+      ) "overlayAudits: ${loc} uses nixpkgs-version but is missing required field 'threshold'";
+
+      assertIssueFields = lib.assertMsg (
+        entry.trackingIssues != [ ]
+      ) "overlayAudits: ${loc} uses nixpkgs-issue but 'trackingIssues' is empty";
+
+      assertPRFields = lib.assertMsg (
+        entry.trackingPRs != [ ]
+      ) "overlayAudits: ${loc} uses nixpkgs-pr but 'trackingPRs' is empty";
+
+      valid =
+        if strategy == "nixpkgs-version" then
+          assertVersionFields
+        else if strategy == "nixpkgs-issue" then
+          assertIssueFields
+        else if strategy == "nixpkgs-pr" then
+          assertPRFields
+        else
+          true;
+    in
+    assert valid;
+    entry;
+
   # Read audit.nix from a host's overlays directory if it exists.
   # host.overlaysModule is the directory path (e.g. hosts/gibson/overlays),
   # so we append /audit.nix to get the sibling file.
   readHostAudits =
-    host:
+    hostKey: host:
     let
       auditFile = host.overlaysModule + "/audit.nix";
+      raw = if builtins.pathExists auditFile then import auditFile else { };
     in
-    if builtins.pathExists auditFile then import auditFile else { };
+    lib.mapAttrs (id: entry: validateEntry hostKey id entry) raw;
 
   # Aggregate per-host audit metadata across all hosts.
   # Keyed by hostname so the CI script can report which host each overlay belongs to.
-  hostAudits = lib.mapAttrs (_name: readHostAudits) hosts;
+  hostAudits = lib.mapAttrs readHostAudits hosts;
 
   # Hook for the system-wide overlay at features/system/core/overlays.nix.
   # This file is imported transitively via systemProfiles and is not reachable
@@ -23,7 +59,12 @@ let
   systemAuditFile = ./../../../features/system/core/overlays/audit.nix;
   systemAudits =
     if builtins.pathExists systemAuditFile then
-      { "features/system/core/overlays" = import systemAuditFile; }
+      let
+        raw = import systemAuditFile;
+      in
+      {
+        "features/system/core/overlays" = lib.mapAttrs (id: entry: validateEntry "system" id entry) raw;
+      }
     else
       { };
 
@@ -56,13 +97,17 @@ in
             attr = lib.mkOption {
               type = lib.types.nullOr lib.types.str;
               default = null;
-              description = "nixpkgs legacyPackages attribute path for version eval (nixpkgs-version only).";
+              description = ''
+                nixpkgs legacyPackages attribute path for version eval (nixpkgs-version only).
+                Defaults to <id>.version if unset — only specify when non-standard
+                (e.g. linuxPackages.nvidiaPackages.new_feature.version).
+              '';
             };
 
             threshold = lib.mkOption {
               type = lib.types.nullOr lib.types.str;
               default = null;
-              description = "Minimum version for the overlay to be considered obsolete (nixpkgs-version only).";
+              description = "Minimum version to consider overlay obsolete (nixpkgs-version only).";
             };
 
             trackingIssues = lib.mkOption {

--- a/hosts/gibson/overlays/audit.nix
+++ b/hosts/gibson/overlays/audit.nix
@@ -1,6 +1,9 @@
-# Audit metadata for temporary overlays — managed by flake/parts/exports/overlay-audits.nix
-# Do not use owner/repo#number syntax anywhere in this file — see audit-overlays.yaml for why.
-#
+# Temporary overlay audit metadata — read by flake/parts/exports/overlay-audits.nix.
+# Keys must match overlay identifiers in default.nix. No owner/repo#N refs (backlinks).
+# Strategies: nixpkgs-version (attr+threshold), nixpkgs-issue (trackingIssues), nixpkgs-pr (trackingPRs).
+# Required fields for all: strategy, description, systems. Optional: notes (coupled removals etc).
+# Coupled overlays with no independent removal condition: add `# audit-exempt` inside their block in default.nix.
+
 {
   bitwarden-desktop = {
     description = "Override electron_39 with electron_39-bin to unblock bitwarden-desktop build";

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -3,7 +3,6 @@
 # Use  "# audit-exempt" comment to items that are coupled with tracked/audited overlays
 {
   inputs,
-  pkgs,
   ...
 }:
 

--- a/hosts/macbook/overlays/audit.nix
+++ b/hosts/macbook/overlays/audit.nix
@@ -1,7 +1,9 @@
-# Audit metadata for temporary overlays in hosts/macbook/overlays/default.nix.
-# Each key must match the overlay identifier used in default.nix.
-# Read by flake/parts/exports/overlay-audits.nix and consumed by the
-# audit-overlays CI workflow. See flake.overlayAudits for option definitions.
+# Temporary overlay audit metadata — read by flake/parts/exports/overlay-audits.nix.
+# Keys must match overlay identifiers in default.nix. No owner/repo#N refs (backlinks).
+# Strategies: nixpkgs-version (attr+threshold), nixpkgs-issue (trackingIssues), nixpkgs-pr (trackingPRs).
+# Required fields for all: strategy, description, systems. Optional: notes (coupled removals etc).
+# Coupled overlays with no independent removal condition: add `# audit-exempt` inside their block in default.nix.
+
 {
   qtwebengine = {
     strategy = "nixpkgs-pr";


### PR DESCRIPTION
Why: Malformed audit.nix entries (wrong or missing strategy fields) only surfaced when CI ran, producing silent bad results or cryptic failures rather than a clear error at authorship time.

What:
- Add `validateEntry` in overlay-audits.nix to assert strategy-specific required fields (threshold, trackingIssues, trackingPRs) via lib.assertMsg at eval time
- Extend pre-commit hook to run `nix eval .#overlayAudits --json` whenever any audit.nix is staged, failing fast with a clear hint on error
- Make `attr` optional for nixpkgs-version strategy in CI, defaulting to `<id>.version` when unset
- Standardize audit.nix header comments to document strategy fields and the audit-exempt convention
