### PR TITLE
fix(overlays): update existing audit issue, drop redundant attr fields

### DIFF
--- a/.github/workflows/audit-overlays.yaml
+++ b/.github/workflows/audit-overlays.yaml
@@ -278,7 +278,10 @@ jobs:
             2>/dev/null | head -n1 || true)
 
           if [ -n "$existing" ]; then
-            echo "Open audit issue already exists (#${existing}) — skipping"
+            echo "Updating existing audit issue #${existing} ..."
+            gh issue edit "$existing" \
+              --body-file "$ISSUE_BODY_FILE"
+            echo "Issue #${existing} updated"
             exit 0
           fi
 

--- a/hosts/gibson/overlays/audit.nix
+++ b/hosts/gibson/overlays/audit.nix
@@ -19,7 +19,6 @@
   };
 
   hyprland = {
-    attr = "hyprland.version";
     description = "Pin hyprland to 0.55.4 while nixpkgs-unstable propagates via Hydra";
     notes = "xdg-desktop-portal-hyprland override is a coupled removal — remove both blocks together.";
     strategy = "nixpkgs-version";
@@ -28,7 +27,6 @@
   };
 
   mpv-unwrapped = {
-    attr = "mpv-unwrapped.version";
     description = "Backport fence-sync fix milestoned for mpv 0.42.0";
     notes = "mpv override is a coupled removal — remove both blocks together.";
     strategy = "nixpkgs-version";
@@ -37,7 +35,6 @@
   };
 
   waybar = {
-    attr = "waybar.version";
     description = "Pin waybar to git-0594574 pending next tagged release";
     notes = "Also remove waybar-patched flake input from flake.nix. Release cadence has been strictly minor bumps since 0.11.0.";
     strategy = "nixpkgs-version";


### PR DESCRIPTION
Why:
- The audit workflow skipped updating an issue when an open issue
already existed, so stale audit reports were never refreshed.
- The `attr` fields in audit.nix were redundant — the audit script now
derives version lookups from the overlay key and `strategy`, not from an
explicit `attr`.

What:
- Replace skip-on-existing logic with `gh issue edit --body-file`
to keep audit issues current
- Remove `attr` from hyprland, mpv-unwrapped, and waybar entries in
audit.nix
