### PR TITLE
chore(ci): add --inputs-from . to nix eval in audit-overlays workflow

### DIFF
--- a/.github/workflows/audit-overlays.yaml
+++ b/.github/workflows/audit-overlays.yaml
@@ -73,7 +73,7 @@ jobs:
             local current
 
             echo "    nix eval nixpkgs#legacyPackages.${system}.${attr} ..." >&2
-            current=$(nix eval --raw "nixpkgs#legacyPackages.${system}.${attr}" 2>/dev/null) || {
+            current=$(nix eval --raw --inputs-from . "nixpkgs#legacyPackages.${system}.${attr}" 2>/dev/null) || {
               echo "    WARNING: eval failed" >&2
               return 2
             }


### PR DESCRIPTION
Why: nix eval was resolving nixpkgs from the global registry rather than the flake's pinned input, causing version drift between the audit and the actual flake lock

What:
- Pass --inputs-from . to nix eval so nixpkgs resolves from the local flake.lock

Notes: Without this, the audit could silently evaluate against a different nixpkgs version than what the flake pins, producing misleading results
