### PR TITLE
fix(gibson): remove hyprland pin now that 0.55.4 has propagated

### DIFF
--- a/hosts/gibson/overlays/audit.nix
+++ b/hosts/gibson/overlays/audit.nix
@@ -18,14 +18,6 @@
     ];
   };
 
-  hyprland = {
-    description = "Pin hyprland to 0.55.4 while nixpkgs-unstable propagates via Hydra";
-    notes = "xdg-desktop-portal-hyprland override is a coupled removal — remove both blocks together.";
-    strategy = "nixpkgs-version";
-    systems = [ "x86_64-linux" ];
-    threshold = "0.55.4";
-  };
-
   mpv-unwrapped = {
     description = "Backport fence-sync fix milestoned for mpv 0.42.0";
     notes = "mpv override is a coupled removal — remove both blocks together.";

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -64,20 +64,6 @@
         doCheck = false;
         nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.catch2_3 ];
       });
-
-      # TODO: Monitor new hyprland package releases
-      # This is currently propagating upstream through Hydra into nixos-unstable
-      hyprland = prev.hyprland.overrideAttrs (old: {
-        version = "0.55.4";
-        src = old.src.override {
-          tag = "v0.55.4";
-          hash = "sha256-IuT0HnOr/0rAw+GXr+OwWx89FjA4Og1FqP7vywEwRJM=";
-        };
-      });
-      xdg-desktop-portal-hyprland = prev.xdg-desktop-portal-hyprland.override {
-        # audit-exempt
-        inherit (final) hyprland; # uses the overridden version above
-      };
     })
 
   ];


### PR DESCRIPTION
Why: The hyprland 0.55.4 pin was a temporary workaround while the release propagated through Hydra into nixos-unstable; it has now landed so the override is no longer needed.

What:
- Drop hyprland and xdg-desktop-portal-hyprland overrides from default.nix
- Remove corresponding hyprland audit entry from audit.nix

Notes: Resolves #218
