### PR TITLE
refactor(doomemacs): move emacs launchd agent into doomemacs module

### DIFF
--- a/features/home/doomemacs/module.nix
+++ b/features/home/doomemacs/module.nix
@@ -108,4 +108,37 @@ mkMerge [
       startWithUserSession = true;
     };
   })
+
+  (mkIf pkgs.stdenv.hostPlatform.isDarwin {
+    launchd.agents.emacs-daemon = {
+      enable = true;
+      config = {
+        ProgramArguments = [
+          "${emacsPkg}/bin/emacs"
+          "--fg-daemon"
+        ];
+        EnvironmentVariables = {
+          PATH = lib.concatStringsSep ":" [
+            "/etc/profiles/per-user/${vars.username}/bin"
+            "/run/current-system/sw/bin"
+            "/nix/var/nix/profiles/default/bin"
+            "/usr/bin"
+            "/bin"
+            "/usr/sbin"
+            "/sbin"
+          ];
+          TERMINFO_DIRS = lib.concatStringsSep ":" [
+            "${pkgs.ghostty-bin.terminfo}/share/terminfo"
+            "${pkgs.ncurses.out}/share/terminfo"
+            "/usr/share/terminfo"
+            "/etc/terminfo"
+          ];
+        };
+        RunAtLoad = true;
+        KeepAlive = true;
+        StandardOutPath = "/tmp/emacs-daemon.log";
+        StandardErrorPath = "/tmp/emacs-daemon.err";
+      };
+    };
+  })
 ]

--- a/hosts/macbook/system.nix
+++ b/hosts/macbook/system.nix
@@ -33,37 +33,6 @@
 
   services.openssh.enable = false;
 
-  launchd.user.agents.emacs-daemon = {
-    serviceConfig = {
-      ProgramArguments = [
-        "${pkgs.emacs}/bin/emacs"
-        "--fg-daemon"
-      ];
-      EnvironmentVariables = {
-        PATH = lib.concatStringsSep ":" [
-          "/etc/profiles/per-user/${vars.username}/bin"
-          "/run/current-system/sw/bin"
-          "/nix/var/nix/profiles/default/bin"
-          "/usr/bin"
-          "/bin"
-          "/usr/sbin"
-          "/sbin"
-        ];
-        TERMINFO_DIRS = lib.concatStringsSep ":" [
-          "${pkgs.ghostty-bin.terminfo}/share/terminfo"
-          "${pkgs.ncurses.out}/share/terminfo"
-          "/usr/share/terminfo"
-          "/etc/terminfo"
-        ];
-      };
-
-      RunAtLoad = true;
-      KeepAlive = true;
-      StandardOutPath = "/tmp/emacs-daemon.log";
-      StandardErrorPath = "/tmp/emacs-daemon.err";
-    };
-  };
-
   system = {
     stateVersion = 5;
     primaryUser = "${vars.username}";


### PR DESCRIPTION
Why: emacs-daemon launchd config lived in hosts/macbook/system.nix, coupling a doomemacs-specific service to a host file and duplicating logic that belongs alongside the rest of the module's Darwin agent definitions.

What:
- Move the emacs-daemon launchd agent from hosts/macbook/system.nix into features/home/doomemacs/module.nix as a darwin-only mkIf block
- Switch the daemon's emacs binary reference from pkgs.emacs to the module's emacsPkg
