### PR TITLE
fix(gibson): pin nixpkgs commit to fix zen kernel build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,7 +711,8 @@
         "qute-dracula": "qute-dracula",
         "sops-nix": "sops-nix",
         "waybar-patched": "waybar-patched",
-        "wayland-pipewire-idle-inhibit": "wayland-pipewire-idle-inhibit"
+        "wayland-pipewire-idle-inhibit": "wayland-pipewire-idle-inhibit",
+        "zen-kernel-fix": "zen-kernel-fix"
       }
     },
     "sops-nix": {
@@ -884,6 +885,23 @@
       "original": {
         "owner": "rafaelrc7",
         "repo": "wayland-pipewire-idle-inhibit",
+        "type": "github"
+      }
+    },
+    "zen-kernel-fix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -54,8 +54,15 @@
     # TODO: remove once https://github.com/NixOS/nixpkgs/pull/515997 lands in
     # nixos-unstable and the macbook overlay is updated accordingly.
     qtwebengine-fix.url = "github:NixOS/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb";
+    qtwebengine-fix.flake = false;
     waybar-patched.url = "github:Alexays/Waybar/0594574";
     waybar-patched.flake = false;
+    #
+    # Temporary: pins a specific nixpkgs commit to fix zen kernel on Linux.
+    # Used in hosts/gibson/hardware-configuration.nix
+    # TODO: remove once something emerges from https://github.com/NixOS/nixpkgs/issues/535850
+    zen-kernel-fix.url = "github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f";
+    zen-kernel-fix.flake = false;
   };
 
   outputs =

--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -7,6 +7,7 @@
   modulesPath,
   system,
   vars,
+  inputs,
   ...
 }:
 
@@ -16,7 +17,13 @@
   ];
 
   boot = {
-    kernelPackages = pkgs.linuxPackages_zen;
+    #kernelPackages = pkgs.linuxPackages_zen;
+    kernelPackages =
+      (import inputs.zen-kernel-fix {
+        inherit system;
+        inherit (pkgs) config;
+      }).linuxPackages_zen;
+
     kernelModules = [
       "nvidia"
       "nvidia_modeset"


### PR DESCRIPTION
Why: linuxPackages_zen fails to build on current nixos-unstable; tracked
upstream with no fix landed yet.

What:
- Add zen-kernel-fix flake input pinned to nixpkgs@567a49d
- Import pinned nixpkgs in hosts/gibson/hardware-configuration.nix to
  source linuxPackages_zen instead of the broken unstable version
- Mark qtwebengine-fix input as non-flake (flake = false) - cheeky
  inclusion
