### PR TITLE
refactor(flake): use flake-parts' built-in modules option

### DIFF
--- a/flake/parts/exports/home-manager.nix
+++ b/flake/parts/exports/home-manager.nix
@@ -1,3 +1,0 @@
-_: {
-  flake.homeManagerModules = { };
-}

--- a/flake/parts/exports/modules.nix
+++ b/flake/parts/exports/modules.nix
@@ -1,8 +1,4 @@
-{ lib, ... }:
+{ inputs, ... }:
 {
-  options.flake.modules = lib.mkOption {
-    type = lib.types.lazyAttrsOf (lib.types.lazyAttrsOf lib.types.anything);
-    default = { };
-    description = "Custom exported module collections.";
-  };
+  imports = [ inputs.flake-parts.flakeModules.modules ];
 }


### PR DESCRIPTION
Why: flake.modules was hand-rolled with a custom lib.mkOption,
duplicating functionality that flake-parts already ships as a standard
module (RTFM)

What:
- Replace the custom flake.modules option in exports/modules.nix with an
  import of inputs.flake-parts.flakeModules.modules
- Remove the now-redundant empty
  exports/home-manager.nix (flake.homeManagerModules = { })
