### PR TITLE
chore(gibson): remove redundant allowUnfree setting

### DIFF
--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -390,7 +390,6 @@ in
     };
   };
 
-  nixpkgs.config.allowUnfree = true;
   # upstream nixpkgs issue - remove when bitwarden-desktop bumps electron
   # TODO: Monitor this for upstream: https://github.com/NixOS/nixpkgs/issues/526914
   nixpkgs.config.permittedInsecurePackages = [ "electron-39.8.10" ];


### PR DESCRIPTION
Why: The recent flake-parts platform refactor sets
`nixpkgs.config.allowUnfree = true` globally in
`flake/parts/platforms/nixos.nix`, making the per-host declaration in
`system.nix` a duplicate.

What:
- Remove `nixpkgs.config.allowUnfree = true` from `hosts/gibson/system.nix`

Notes: Effective behaviour is unchanged; unfree packages remain allowed via the platform-level module.
