### PR TITLE
refactor(yubikey): extract yubikey config into a dedicated system module

### DIFF
--- a/features/system/core/yubikey/_module.nix
+++ b/features/system/core/yubikey/_module.nix
@@ -1,0 +1,50 @@
+{
+  config,
+  pkgs,
+  vars,
+  hostname,
+  ...
+}:
+{
+  security.pam.u2f = {
+    enable = true;
+    control = "sufficient";
+    settings = {
+      cue = true;
+      origin = "pam://${hostname}";
+      appid = "pam://${hostname}";
+      authFile = config.sops.secrets."system/pam/yubikeyPub".path;
+    };
+  };
+
+  security.pam.services = {
+    login.u2fAuth = true;
+    sudo.u2fAuth = true;
+    sddm.u2fAuth = true;
+    hyprlock.u2fAuth = true;
+  };
+
+  sops.secrets."system/pam/yubikeyPub".owner = vars.username;
+
+  services.pcscd = {
+    enable = true;
+    plugins = [ pkgs.ccid ];
+  };
+
+  systemd.services.pcscd-resume = {
+    description = "Restart pcscd after hibernate resume";
+    wantedBy = [ "post-resume.target" ];
+    after = [ "post-resume.target" ];
+    script = ''
+      sleep 3
+      ${pkgs.systemd}/bin/systemctl restart pcscd
+    '';
+    serviceConfig.Type = "oneshot";
+  };
+
+  services.udev.packages = with pkgs; [
+    yubikey-manager
+    yubikey-personalization
+    libu2f-host
+  ];
+}

--- a/features/system/core/yubikey/default.nix
+++ b/features/system/core/yubikey/default.nix
@@ -1,0 +1,3 @@
+_: {
+  flake.modules.nixos.yubikey = ./_module.nix;
+}

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -121,16 +121,6 @@ in
         wantedBy = [ "multi-user.target" ];
         serviceConfig.Restart = "always";
       };
-      pcscd-resume = {
-        description = "Restart pcscd after hibernate resume";
-        wantedBy = [ "post-resume.target" ];
-        after = [ "post-resume.target" ];
-        script = ''
-          sleep 3
-          ${pkgs.systemd}/bin/systemctl restart pcscd
-        '';
-        serviceConfig.Type = "oneshot";
-      };
     };
   };
 
@@ -184,29 +174,9 @@ in
   security = {
     polkit.enable = true;
     rtkit.enable = true;
-
-    pam = {
-      u2f = {
-        enable = true;
-        control = "sufficient";
-        settings = {
-          cue = true;
-          origin = "pam://gibson";
-          appid = "pam://gibson";
-          authFile = config.sops.secrets."system/pam/yubikeyPub".path;
-        };
-      };
-
-      services = {
-        login.u2fAuth = true;
-        sudo.u2fAuth = true;
-        sddm.u2fAuth = true;
-        hyprlock.u2fAuth = true;
-      };
-    };
   };
-  # List services that you want to enable:
 
+  # List services that you want to enable:
   services = {
     pipewire = {
       enable = true;
@@ -252,11 +222,6 @@ in
       };
     };
 
-    pcscd = {
-      enable = true;
-      plugins = [ pkgs.ccid ];
-    };
-
     upower.enable = true;
 
     dbus = {
@@ -268,11 +233,6 @@ in
 
     udev = {
       enable = true;
-      packages = with pkgs; [
-        yubikey-manager
-        yubikey-personalization
-        libu2f-host
-      ];
       extraRules = ''
         # SteelSeries Aerox 5
         SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1850", MODE="0666"
@@ -417,12 +377,6 @@ in
     defaultSopsFormat = "yaml";
 
     secrets = {
-
-      # Yubikey
-      "system/pam/yubikeyPub" = {
-        owner = "${vars.username}";
-      };
-
       # System
       "system/gibson_user_pass" = {
         neededForUsers = true;

--- a/profiles/system/nixos.nix
+++ b/profiles/system/nixos.nix
@@ -9,6 +9,7 @@
     inputs.self.modules.nixos.nix-settings
     inputs.self.modules.nixos.overlays
     inputs.self.modules.nixos.security
+    inputs.self.modules.nixos.yubikey
     inputs.self.modules.nixos.containers-pentesting
     inputs.self.modules.nixos.containers-virtualisation
   ];


### PR DESCRIPTION
Why: YubiKey PAM, pcscd, and udev config was hardcoded in gibson's
system.nix, making it non-reusable across hosts

What:
- Add `features/system/core/yubikey/_module.nix` with PAM u2f, pcscd,
  pcscd-resume, and udev rules
- Register the module via `default.nix` and wire it into the nixos
  system profile
- Remove all yubikey-specific config from `hosts/gibson/system.nix`
