### PR TITLE
fix(yubikey): correct pcscd resume target and reduce sleep delay

### DIFF
--- a/features/system/core/yubikey/_module.nix
+++ b/features/system/core/yubikey/_module.nix
@@ -33,10 +33,10 @@
 
   systemd.services.pcscd-resume = {
     description = "Restart pcscd after hibernate resume";
-    wantedBy = [ "post-resume.target" ];
-    after = [ "post-resume.target" ];
+    wantedBy = [ "hibernate.target" ];
+    after = [ "hibernate.target" ];
     script = ''
-      sleep 3
+      sleep 1
       ${pkgs.systemd}/bin/systemctl restart pcscd
     '';
     serviceConfig.Type = "oneshot";


### PR DESCRIPTION
Why: pcscd was not reliably restarting after hibernate because
 `post-resume.target` is not the correct systemd target for
  hibernate wake; `hibernate.target` is the proper hook point.
  The 3-second sleep was also unnecessarily long.

What:
- Switch wantedBy/after from post-resume.target to hibernate.target
- Reduce post-hibernate sleep from 3s to 1s
