### PR TITLE
fix(ci): scope concurrency groups to PR number or commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}:${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
Why: the previous group key used `github.ref`, which caused pushes
to the same branch (e.g. main) to cancel each other's runs
unintentionally, rather than scoping cancellation to a specific
PR or push event.

What:
- replace `github.ref` with a conditional that uses the PR number
  for pull_request events and the commit SHA for push events
