### PR TITLE
chore(ci): pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
       github-actions:
         patterns:
           - "*"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/audit-overlays.yaml
+++ b/.github/workflows/audit-overlays.yaml
@@ -11,23 +11,26 @@ on:
 jobs:
   audit:
     name: Check overlay obsolescence
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install Nix
-        uses: DeterminateSystems/determinate-nix-action@v3
+        uses: DeterminateSystems/determinate-nix-action@131015bad844610e5e6300f8a143bf625d3e74f4
 
-      - name: Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@9926dde74484ccb2224835b80531de64ed4336ef
 
       # Required for private flake inputs (nix-secrets etc.) during nix eval
       - name: Start ssh-agent and add deploy read-only key
-        uses: webfactory/ssh-agent@v0.10.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555
         with:
           ssh-private-key: ${{ secrets.CI_GITHUB_SSH_KEY }}
 

--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -11,18 +11,19 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install Nix
-        uses: DeterminateSystems/determinate-nix-action@v3
+        uses: DeterminateSystems/determinate-nix-action@131015bad844610e5e6300f8a143bf625d3e74f4
 
-      - name: Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@9926dde74484ccb2224835b80531de64ed4336ef
 
       - name: Start ssh-agent and add deploy read-only key (private flake inputs)
-        uses: webfactory/ssh-agent@v0.10.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555
         with:
           ssh-private-key: ${{ secrets.CI_GITHUB_SSH_KEY }}
 
@@ -43,7 +44,7 @@ jobs:
 
       - name: Update flake.lock (create PR)
         id: update
-        uses: DeterminateSystems/update-flake-lock@v28
+        uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6
         with:
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
 
@@ -62,7 +63,7 @@ jobs:
 
       # Enable auto-merge for the PR that was just created/updated
       - name: Enable auto-merge
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d
         with:
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
           pull-request-number: ${{ steps.update.outputs.pull-request-number }}


### PR DESCRIPTION
Why: mutable version tags (v3, main, v28) allow upstream action
  changes to silently affect CI without a review; pinning to SHAs
  locks the exact code that runs and enables dependabot to manage
  updates explicitly.

What:
- pin actions/checkout, DeterminateSystems/determinate-nix-action,
  webfactory/ssh-agent, DeterminateSystems/update-flake-lock, and
  peter-evans/enable-pull-request-automerge to full commit SHAs
- replace magic-nix-cache-action with flakehub-cache-action (pinned)
  in both audit-overlays and update-flake-lock workflows
- add id-token: write permission to both workflows (required by
  FlakeHub cache action)
- configure dependabot commit-message prefix to "chore" with scope
  so auto-update PRs follow the repo commit convention
