### PR TITLE
chore: replace grep -P with grep -E in commit-msg hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -2,7 +2,7 @@
 MSG=$(cat "$1")
 PATTERN='^(feat|fix|refactor|chore|docs|test|revert)(\([a-z0-9_-]+\))?: .{1,72}$'
 
-if ! echo "$MSG" | head -1 | grep -Pq "$PATTERN"; then
+if ! echo "$MSG" | head -1 | grep -Eq "$PATTERN"; then
   echo "✗ Commit title doesn't match convention:"
   echo "  <type>(<scope>): <description>"
   echo "  Example types: feat fix refactor repo chore docs test revert"


### PR DESCRIPTION
Why: grep -P (PCRE) is not available on all systems, causing the
  commit-msg hook to fail on macOS where grep is BSD-based.

What:
- swap -P flag for -E (extended regex) in the pattern match
- the pattern uses no PCRE-only features so -E is fully equivalent
