### PR TITLE
fix(gibson): replace zen-kernel nixpkgs pin with kernelFile workaround

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,8 +711,7 @@
         "qute-dracula": "qute-dracula",
         "sops-nix": "sops-nix",
         "waybar-patched": "waybar-patched",
-        "wayland-pipewire-idle-inhibit": "wayland-pipewire-idle-inhibit",
-        "zen-kernel-fix": "zen-kernel-fix"
+        "wayland-pipewire-idle-inhibit": "wayland-pipewire-idle-inhibit"
       }
     },
     "sops-nix": {
@@ -885,23 +884,6 @@
       "original": {
         "owner": "rafaelrc7",
         "repo": "wayland-pipewire-idle-inhibit",
-        "type": "github"
-      }
-    },
-    "zen-kernel-fix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -57,12 +57,6 @@
     qtwebengine-fix.flake = false;
     waybar-patched.url = "github:Alexays/Waybar/0594574";
     waybar-patched.flake = false;
-    #
-    # Temporary: pins a specific nixpkgs commit to fix zen kernel on Linux.
-    # Used in hosts/gibson/hardware-configuration.nix
-    # TODO: remove once something emerges from https://github.com/NixOS/nixpkgs/issues/535850
-    zen-kernel-fix.url = "github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f";
-    zen-kernel-fix.flake = false;
   };
 
   outputs =

--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -16,14 +16,13 @@
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
-  boot = {
-    #kernelPackages = pkgs.linuxPackages_zen;
-    kernelPackages =
-      (import inputs.zen-kernel-fix {
-        inherit system;
-        inherit (pkgs) config;
-      }).linuxPackages_zen;
+  # Temporary: fix zen kernel builds on Linux.
+  # https://nixpk.gs/pr-tracker.html?pr=536173 - can be removed post flake lock update
+  # TODO: remove once https://github.com/NixOS/nixpkgs/pull/536173 merges upstream
+  system.boot.loader.kernelFile = "vmlinuz";
 
+  boot = {
+    kernelPackages = pkgs.linuxPackages_zen;
     kernelModules = [
       "nvidia"
       "nvidia_modeset"


### PR DESCRIPTION
Why: the pinned nixpkgs flake input was a heavy workaround for the zen
  kernel build failure; a simpler fix exists by setting
  system.boot.loader.kernelFile directly

What:
- remove zen-kernel-fix flake input and its lock entry
- restore pkgs.linuxPackages_zen as the kernel package source
- add system.boot.loader.kernelFile = "vmlinuz" as new workaround
