### PR TITLE
chore: remove .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-.DS_Store
-.ci-secrets
-secrets/
-lost+found


### PR DESCRIPTION
Why: the file is being deleted entirely; these ignore
  rules are no longer needed.

What:
- remove the .gitignore file from the repo
