### PR TITLE
feat(tailscale): add tailscale as a system-wide feature module

### DIFF
--- a/features/system/tailscale/_module.nix
+++ b/features/system/tailscale/_module.nix
@@ -1,0 +1,3 @@
+_: {
+  services.tailscale.enable = true;
+}

--- a/features/system/tailscale/default.nix
+++ b/features/system/tailscale/default.nix
@@ -1,0 +1,4 @@
+_: {
+  flake.modules.nixos.tailscale = ./_module.nix;
+  flake.modules.darwin.tailscale = ./_module.nix;
+}

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -35,6 +35,11 @@ in
       internalInterfaces = [ "ve-pentesting" ];
       externalInterface = "enp7s0";
     };
+
+    firewall = {
+      trustedInterfaces = [ config.services.tailscale.interfaceName ];
+      allowedUDPPorts = [ config.services.tailscale.port ];
+    };
   };
 
   # Select internationalisation properties.

--- a/profiles/system/darwin.nix
+++ b/profiles/system/darwin.nix
@@ -9,5 +9,6 @@
     inputs.self.modules.darwin.nix-settings
     inputs.self.modules.darwin.overlays
     inputs.self.modules.darwin.security
+    inputs.self.modules.darwin.tailscale
   ];
 }

--- a/profiles/system/nixos.nix
+++ b/profiles/system/nixos.nix
@@ -9,6 +9,7 @@
     inputs.self.modules.nixos.nix-settings
     inputs.self.modules.nixos.overlays
     inputs.self.modules.nixos.security
+    inputs.self.modules.nixos.tailscale
     inputs.self.modules.nixos.yubikey
     inputs.self.modules.nixos.containers-pentesting
     inputs.self.modules.nixos.containers-virtualisation


### PR DESCRIPTION
Why: Intent to allow intergration of attic cache with github CI

What:
- add features/system/tailscale with a flake module that enables
  services.tailscale
- wire the module into both nixos and darwin system profiles
- configure gibson's firewall to trust the tailscale interface and
  open the required UDP port
