### PR TITLE
refactor(sops): extract base sops config into shared feature module

### DIFF
--- a/features/system/sops-nix/_module.nix
+++ b/features/system/sops-nix/_module.nix
@@ -1,0 +1,11 @@
+{
+  vars,
+  ...
+}:
+{
+  sops = {
+    age.keyFile = "${vars.age.keyFile}";
+    defaultSopsFile = "${vars.secretsPath}/secrets/secrets.yaml";
+    defaultSopsFormat = "yaml";
+  };
+}

--- a/features/system/sops-nix/default.nix
+++ b/features/system/sops-nix/default.nix
@@ -1,0 +1,4 @@
+_: {
+  flake.modules.nixos.sops-nix = ./_module.nix;
+  flake.modules.darwin.sops-nix = ./_module.nix;
+}

--- a/flake/parts/platforms/darwin.nix
+++ b/flake/parts/platforms/darwin.nix
@@ -24,6 +24,9 @@ let
         host.systemProfiles
         ++ host.modules
         ++ [ { nixpkgs.config.allowUnfree = true; } ]
+        ++ [
+          inputs.sops-nix.darwinModules.sops
+        ]
         ++ repoLib.mkHomeManagerModule {
           platformModule = inputs.home-manager.darwinModules.home-manager;
           inherit host;

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -377,10 +377,6 @@ in
   };
 
   sops = {
-    age.keyFile = "${vars.age.keyFile}";
-    defaultSopsFile = "${vars.secretsPath}/secrets/secrets.yaml";
-    defaultSopsFormat = "yaml";
-
     secrets = {
       # System
       "system/gibson_user_pass" = {

--- a/profiles/system/darwin.nix
+++ b/profiles/system/darwin.nix
@@ -9,6 +9,7 @@
     inputs.self.modules.darwin.nix-settings
     inputs.self.modules.darwin.overlays
     inputs.self.modules.darwin.security
+    inputs.self.modules.darwin.sops-nix
     inputs.self.modules.darwin.tailscale
   ];
 }

--- a/profiles/system/nixos.nix
+++ b/profiles/system/nixos.nix
@@ -9,6 +9,7 @@
     inputs.self.modules.nixos.nix-settings
     inputs.self.modules.nixos.overlays
     inputs.self.modules.nixos.security
+    inputs.self.modules.nixos.sops-nix
     inputs.self.modules.nixos.tailscale
     inputs.self.modules.nixos.yubikey
     inputs.self.modules.nixos.containers-pentesting


### PR DESCRIPTION
Why: sops age key and default secrets path config was hardcoded in
  gibson's host config; extracting it makes it reusable across all
  hosts without duplication

What:
- add features/system/sops-nix module with shared sops base config
  (age keyFile, defaultSopsFile, defaultSopsFormat)
- register module for both nixos and darwin flake module outputs
- wire module into profiles/system/nixos.nix so all nixos hosts
  inherit it automatically
- wire module into profiles/system/darwin.nix so all darwin hosts
  inherit it automatically
- remove now-duplicate sops base config from hosts/gibson/system.nix
- include sops-nix darwinModules.sops in darwin platform builder so
  the sops feature module is available on darwin hosts
