### PR TITLE
feat(attic-client): add attic feature module with watch-store service

### DIFF
--- a/features/system/attic-client/_darwin.nix
+++ b/features/system/attic-client/_darwin.nix
@@ -1,0 +1,21 @@
+{ config, pkgs, ... }:
+{
+  sops.secrets."services/attic/token" = { };
+
+  launchd.daemons.attic-watch-store = {
+    script = ''
+      set -euo pipefail
+      export HOME=/var/lib/attic-watch-store
+      mkdir -p "$HOME"
+      ${pkgs.attic-client}/bin/attic login home \
+        http://192.168.1.110:8080 "$(cat ${config.sops.secrets."services/attic/token".path})"
+      exec ${pkgs.attic-client}/bin/attic watch-store home:home-cache
+    '';
+    serviceConfig = {
+      KeepAlive = true;
+      RunAtLoad = true;
+      StandardOutPath = "/var/log/attic-watch-store.stdout.log";
+      StandardErrorPath = "/var/log/attic-watch-store.stderr.log";
+    };
+  };
+}

--- a/features/system/attic-client/_nixos.nix
+++ b/features/system/attic-client/_nixos.nix
@@ -1,0 +1,24 @@
+{ config, pkgs, ... }:
+{
+  sops.secrets."services/attic/token" = { };
+
+  systemd.services.attic-watch-store = {
+    description = "Push new Nix store paths to attic";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
+    serviceConfig = {
+      Type = "simple";
+      StateDirectory = "attic-watch-store";
+      Environment = "HOME=%S/attic-watch-store";
+      ExecStart = pkgs.writeShellScript "attic-watch-store-start" ''
+        set -euo pipefail
+        ${pkgs.attic-client}/bin/attic login home \
+          http://192.168.1.110:8080 "$(cat ${config.sops.secrets."services/attic/token".path})"
+        exec ${pkgs.attic-client}/bin/attic watch-store home:home-cache
+      '';
+      Restart = "on-failure";
+      RestartSec = 10;
+    };
+  };
+}

--- a/features/system/attic-client/default.nix
+++ b/features/system/attic-client/default.nix
@@ -1,0 +1,4 @@
+_: {
+  flake.modules.nixos.attic-client = ./_nixos.nix;
+  flake.modules.darwin.attic-client = ./_darwin.nix;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -408,11 +408,11 @@
     "nix-secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1780790065,
-        "narHash": "sha256-oZVOoa7yskwukNHkQO6gLAs4wg8rKf3ojm52yOmOg4A=",
+        "lastModified": 1783181149,
+        "narHash": "sha256-rRWY3Nzo+UyDBfV4yNeQjpw9x7qo3MK7QcsI+rD9F/8=",
         "ref": "main",
-        "rev": "00e556af4a8a92b20395b78f0b8f273569b6c488",
-        "revCount": 23,
+        "rev": "341cbcafdbd055c0e4663107c8a788d9e81456bd",
+        "revCount": 24,
         "type": "git",
         "url": "ssh://git@github.com/5ysk3y/nix-secrets.git"
       },

--- a/profiles/system/darwin.nix
+++ b/profiles/system/darwin.nix
@@ -4,6 +4,7 @@
 }:
 {
   imports = [
+    inputs.self.modules.darwin.attic-client
     inputs.self.modules.darwin.editor
     inputs.self.modules.darwin.locale
     inputs.self.modules.darwin.nix-settings

--- a/profiles/system/nixos.nix
+++ b/profiles/system/nixos.nix
@@ -4,6 +4,7 @@
 }:
 {
   imports = [
+    inputs.self.modules.nixos.attic-client
     inputs.self.modules.nixos.editor
     inputs.self.modules.nixos.locale
     inputs.self.modules.nixos.nix-settings


### PR DESCRIPTION
Why: new binary cache infrastructure needs clients to automatically push
  store paths; no prior mechanism existed to keep the attic cache
  populated across machines.

What:
- add cross-platform module (_nixos/darwin.nix) with systemd
  service (Linux) and launchd daemon (Darwin) that logs in and runs
  attic watch-store
- expose module via flake.modules.nixos/darwin in default.nix
- wire attic-client into the NixOS system profile
- wire attic-client into the Darwin system profile
- bump nix-secrets lock to pick up the new attic token secret
