### PR TITLE
fix(attic-client): add --ignore-upstream-cache-filter to watch-store

### DIFF
--- a/features/system/attic-client/_darwin.nix
+++ b/features/system/attic-client/_darwin.nix
@@ -9,7 +9,7 @@
       mkdir -p "$HOME"
       ${pkgs.attic-client}/bin/attic login home \
         http://192.168.1.110:8080 "$(cat ${config.sops.secrets."services/attic/token".path})"
-      exec ${pkgs.attic-client}/bin/attic watch-store home:home-cache
+      exec ${pkgs.attic-client}/bin/attic watch-store --ignore-upstream-cache-filter home:home-cache
     '';
     serviceConfig = {
       KeepAlive = true;

--- a/features/system/attic-client/_nixos.nix
+++ b/features/system/attic-client/_nixos.nix
@@ -15,7 +15,7 @@
         set -euo pipefail
         ${pkgs.attic-client}/bin/attic login home \
           http://192.168.1.110:8080 "$(cat ${config.sops.secrets."services/attic/token".path})"
-        exec ${pkgs.attic-client}/bin/attic watch-store home:home-cache
+        exec ${pkgs.attic-client}/bin/attic watch-store --ignore-upstream-cache-filter home:home-cache
       '';
       Restart = "on-failure";
       RestartSec = 10;


### PR DESCRIPTION
Why: watch-store was skipping paths already present in upstream
  binary caches, causing locally-built derivations to not be
  pushed to the home cache.

What:
- Pass --ignore-upstream-cache-filter to attic watch-store on
  both Darwin and NixOS so all store paths are pushed regardless
  of upstream cache hits
