### PR TITLE
fix(flake): change update-flake-lock cron schedule to 04:37 UTC

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -3,7 +3,7 @@ name: Update flake.lock
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "0 7 * * 0"
+    - cron: "37 4 * * 0"
 
 jobs:
   update-flake-lock:


### PR DESCRIPTION
Why: default round-number cron times (e.g. 07:00) cause thundering
  herd on shared CI infrastructure; staggered times reduce contention

What:
- update weekly schedule from "0 7 * * 0" to "37 4 * * 0"
