### PR TITLE
fix(gibson): remove temporary zen kernel build workaround

### DIFF
--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -16,11 +16,6 @@
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
-  # Temporary: fix zen kernel builds on Linux.
-  # https://nixpk.gs/pr-tracker.html?pr=536173 - can be removed post flake lock update
-  # TODO: remove once https://github.com/NixOS/nixpkgs/pull/536173 merges upstream
-  system.boot.loader.kernelFile = "vmlinuz";
-
   boot = {
     kernelPackages = pkgs.linuxPackages_zen;
     kernelModules = [


### PR DESCRIPTION
Why: the vmlinuz kernelFile override was a stopgap for a zen kernel
build failure on nixpkgs; the upstream fix has since merged, so it's no
longer needed.

What:
- drop the system.boot.loader.kernelFile override and its
  explanatory comments from hosts/gibson/hardware-configuration.nix
