### PR TITLE
chore(ci): change update-flake-lock cron schedule

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -3,7 +3,7 @@ name: Update flake.lock
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "37 4 * * 0"
+    - cron: "51 1 * * 6"
 
 jobs:
   update-flake-lock:


### PR DESCRIPTION
Why: Moved automated flake updates to Saturday, instead of Sunday, and
changed the time to even earlier (just before 2am) - there always seems
to be delay anyway.

What:
- change flake.lock update cron from "37 4 * * 0" (Sun 04:37) to
  "51 1 * * 6" (Sat 01:51)
