### PR TITLE
fix(gibson): pin setuptools for wfuzz to unbreak pentesting build

### DIFF
--- a/features/system/containers/pentesting/_module.nix
+++ b/features/system/containers/pentesting/_module.nix
@@ -1,5 +1,6 @@
 {
   vars,
+  inputs,
   ...
 }:
 
@@ -49,8 +50,22 @@ in
 
         nixpkgs.config.allowUnfree = true;
         nixpkgs.overlays = [
-          (_final: _prev: {
-          })
+          (
+            final: prev:
+            let
+              pinnedPkgs = import inputs.nixpkgs-setuptools-pin { inherit (prev) system; };
+            in
+            {
+              python314Packages = prev.python314Packages // {
+                wfuzz = prev.python314Packages.wfuzz.override {
+                  setuptools = prev.python314Packages.setuptools.overridePythonAttrs (old: {
+                    version = pinnedPkgs.python314Packages.setuptools.version;
+                    src = pinnedPkgs.python314Packages.setuptools.src;
+                  });
+                };
+              };
+            }
+          )
         ];
 
         networking = {

--- a/flake.lock
+++ b/flake.lock
@@ -460,6 +460,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-setuptools-pin": {
+      "locked": {
+        "lastModified": 1775781922,
+        "narHash": "sha256-CcqiN6UcbqTHr3j6rPEKCf/vuw3JF8xpisPnjov8P14=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bc69cb503d4a70df1f12ea9fad63366ed6f62b3c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bc69cb503d4a70df1f12ea9fad63366ed6f62b3c",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1783148766,
@@ -684,6 +700,7 @@
         "nix-gaming": "nix-gaming",
         "nix-secrets": "nix-secrets",
         "nixpkgs": "nixpkgs_8",
+        "nixpkgs-setuptools-pin": "nixpkgs-setuptools-pin",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "qtwebengine-fix": "qtwebengine-fix",
         "qute-dracula": "qute-dracula",

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,12 @@
     qtwebengine-fix.flake = false;
     waybar-patched.url = "github:Alexays/Waybar/0594574";
     waybar-patched.flake = false;
+
+    # Temporary: pins a specific nixpkgs commit to fix Python Setuptools
+    # on Linux.
+    # Used only in features/system/containers/pentesting/_module.nix
+    # TODO: Monitor nixpkgs upstream for an issue/PR to track this
+    nixpkgs-setuptools-pin.url = "github:NixOS/nixpkgs/bc69cb503d4a70df1f12ea9fad63366ed6f62b3c";
   };
 
   outputs =


### PR DESCRIPTION
Why: wfuzz on python314 fails to build against the current nixpkgs
  setuptools version, breaking the pentesting container.

What:
- add nixpkgs-setuptools-pin flake input locked to a known-good
  nixpkgs commit
- override python314Packages.wfuzz's setuptools dependency with the
  pinned version via an overlay in the pentesting container module
