### PR TITLE
fix(attic-client): limit watch-store push concurrency to 1 job

### DIFF
--- a/features/system/attic-client/_darwin.nix
+++ b/features/system/attic-client/_darwin.nix
@@ -9,7 +9,7 @@
       mkdir -p "$HOME"
       ${pkgs.attic-client}/bin/attic login home \
         http://192.168.1.110:8080 "$(cat ${config.sops.secrets."services/attic/token".path})"
-      exec ${pkgs.attic-client}/bin/attic watch-store --ignore-upstream-cache-filter home:home-cache
+      exec ${pkgs.attic-client}/bin/attic watch-store --ignore-upstream-cache-filter -j 1 home:home-cache
     '';
     serviceConfig = {
       KeepAlive = true;

--- a/features/system/attic-client/_nixos.nix
+++ b/features/system/attic-client/_nixos.nix
@@ -15,7 +15,7 @@
         set -euo pipefail
         ${pkgs.attic-client}/bin/attic login home \
           http://192.168.1.110:8080 "$(cat ${config.sops.secrets."services/attic/token".path})"
-        exec ${pkgs.attic-client}/bin/attic watch-store --ignore-upstream-cache-filter home:home-cache
+        exec ${pkgs.attic-client}/bin/attic watch-store --ignore-upstream-cache-filter -j 1 home:home-cache
       '';
       Restart = "on-failure";
       RestartSec = 10;


### PR DESCRIPTION
Why: attic watch-store was pushing multiple store paths concurrently,
  which could saturate bandwidth/resources on the home server.

What:
- add -j 1 to the watch-store invocation in both the darwin and nixos
  attic-client modules

Notes: applies identically to both darwin and nixos launchd/systemd
  units to keep behavior consistent across hosts
