### PR TITLE
chore(ci): disable flakehub gh-actions cache, drop darwin cleanup

### DIFF
--- a/.github/workflows/ci-full-build.yml
+++ b/.github/workflows/ci-full-build.yml
@@ -76,6 +76,8 @@ jobs:
             extra-substituters = http://attic.taileda465.ts.net:8080/home-cache
             extra-trusted-public-keys = home-cache:E1OhBtGAhOkDjZortT+YYKTyNZ5/gPCcaQ/ryGKUPdU=
       - uses: DeterminateSystems/flakehub-cache-action@8ceb5534cc3f9ba4f1083af0ab4ce21b6c19217f
+        with:
+          github-actions-cache: disabled
       - name: Start ssh-agent and add deploy key
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555
         with:
@@ -130,16 +132,12 @@ jobs:
             extra-substituters = http://attic.taileda465.ts.net:8080/home-cache
             extra-trusted-public-keys = home-cache:E1OhBtGAhOkDjZortT+YYKTyNZ5/gPCcaQ/ryGKUPdU=
       - uses: DeterminateSystems/flakehub-cache-action@8ceb5534cc3f9ba4f1083af0ab4ce21b6c19217f
+        with:
+          github-actions-cache: disabled
       - name: Start ssh-agent and add deploy key
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555
         with:
           ssh-private-key: ${{ secrets.CI_GITHUB_SSH_KEY }}
-      - name: Free up disk space
-        run: |
-          set -euo pipefail
-          df -h
-          sudo rm -rf /usr/share/dotnet /opt/ghc /opt/hostedtoolcache /usr/local/lib/android
-          df -h
       - name: Add GitHub to known_hosts
         run: |
           set -euo pipefail


### PR DESCRIPTION
Why: full builds now push closures to the attic cache, so GitHub
Actions' own cache was redundant and the manual disk-space cleanup
step was no longer needed to keep the darwin runner from filling up.

What:
- disable github-actions-cache in flakehub-cache-action for both jobs
- remove the "Free up disk space" step that pruned dotnet/ghc/android
  toolcaches as it isnt relevant for darwin
