### PR TITLE
chore(pkgs): bump xivlauncher-rb to 1.4.0.8

### DIFF
--- a/pkgs/nixos-xivlauncher-rb/default.nix
+++ b/pkgs/nixos-xivlauncher-rb/default.nix
@@ -19,7 +19,7 @@
 }:
 
 let
-  tag = "1.4.0.7";
+  tag = "1.4.0.8";
 in
 buildDotnetModule rec {
   pname = "xivlauncher-rb";


### PR DESCRIPTION
Why: match upstream rankynbass/XIVLauncher.Core rb-v1.4.0.8 release

What:
- bump tag from 1.4.0.7 to 1.4.0.8 in nixos-xivlauncher-rb
