### PR TITLE
fix(gibson): enable pointer cursor theme in home-manager

### DIFF
--- a/hosts/gibson/home.nix
+++ b/hosts/gibson/home.nix
@@ -14,6 +14,7 @@
     homeDirectory = "/home/${vars.username}";
 
     pointerCursor = {
+      enable = true;
       gtk.enable = true;
       package = pkgs.bibata-cursors;
       name = "Bibata-Modern-Classic";


### PR DESCRIPTION
Why: home-manager now gives explicit warnings on rebuild to set this in
config so this does just that

What:
- set pointerCursor.enable = true in hosts/gibson/home.nix
