### PR TITLE
chore(pkgs): update xivlauncher-rb fetch hash

### DIFF
--- a/pkgs/nixos-xivlauncher-rb/default.nix
+++ b/pkgs/nixos-xivlauncher-rb/default.nix
@@ -29,7 +29,7 @@ buildDotnetModule rec {
     owner = "rankynbass";
     repo = "XIVLauncher.Core";
     rev = "rb-v${tag}";
-    hash = "sha256-ErTNmxnHJyzeJBvVWHi+8MiU6HgsWojsWxdg12yBorA=";
+    hash = "sha256-hZCuxGdaH+UuYK+pARocBDggE+pQ0WNJWfw+M96LFhY=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Why: source hash for the pinned rev no longer matches, breaking
the CI build

What:
- update fetchFromGitHub hash for XIVLauncher.Core rb-v${tag}
