### PR TITLE
fix(doomemacs): include doom config contents in sync-stamp key

### DIFF
--- a/features/home/doomemacs/_module.nix
+++ b/features/home/doomemacs/_module.nix
@@ -75,7 +75,8 @@ mkMerge [
           ${inputs.doomemacs-modules}/ "$EMACSDIR/sources/doom+/"
 
         stamp="${config.xdg.stateHome}/doom/sync-stamp"
-        key="${emacsPkg}|${inputs.doomemacs}|${inputs.doomemacs-modules}"
+        doomcfg_hash=$(find "${config.xdg.configHome}/doom" -type f | sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
+        key="${emacsPkg}|${inputs.doomemacs}|${inputs.doomemacs-modules}|$doomcfg_hash"
 
         if [ ! -f "$stamp" ] || [ "$(cat "$stamp")" != "$key" ]; then
           echo "doom: inputs changed, running doom sync -u --force"


### PR DESCRIPTION
Why: config edits under $XDG_CONFIG_HOME/doom were not triggering a
doom sync, since the stamp key only tracked emacs package and doom
input versions, not the config's own contents.

What:
- hash all files under the doom config dir and fold it into the
  sync-stamp key
- trigger doom sync -u --force when that hash changes

Notes: hashes every file's sha256sum then sha256sums the list, so
sync fires on any content change, add/remove, or rename under the
doom config dir.
