### PR TITLE
fix(ci): retry attic cache push on transient failures

### DIFF
--- a/.github/workflows/ci-full-build.yml
+++ b/.github/workflows/ci-full-build.yml
@@ -100,10 +100,14 @@ jobs:
           nix build .#nixosConfigurations.gibson.config.system.build.toplevel --no-write-lock-file
       - name: Push built closure to attic
         continue-on-error: true
-        run: |
-          set -euo pipefail
-          nix run nixpkgs#attic-client -- login home http://attic.taileda465.ts.net:8080 "${{ secrets.TS_CI_ATTIC_PUSH_TOKEN }}"
-          nix run nixpkgs#attic-client -- push home:home-cache --ignore-upstream-cache-filter -j 1 ./result
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          command: |
+            set -euo pipefail
+            nix run nixpkgs#attic-client -- login home http://attic.taileda465.ts.net:8080 "${{ secrets.TS_CI_ATTIC_PUSH_TOKEN }}"
+            nix run nixpkgs#attic-client -- push home:home-cache --ignore-upstream-cache-filter -j 1 ./result
 
   darwin-eval-check:
     name: full build check (darwin)
@@ -156,7 +160,11 @@ jobs:
           nix build .#darwinConfigurations.macbook.config.system.build.toplevel --no-write-lock-file
       - name: Push built closure to attic
         continue-on-error: true
-        run: |
-          set -euo pipefail
-          nix run nixpkgs#attic-client -- login home http://attic.taileda465.ts.net:8080 "${{ secrets.TS_CI_ATTIC_PUSH_TOKEN }}"
-          nix run nixpkgs#attic-client -- push home:home-cache --ignore-upstream-cache-filter -j 1 ./result
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          command: |
+            set -euo pipefail
+            nix run nixpkgs#attic-client -- login home http://attic.taileda465.ts.net:8080 "${{ secrets.TS_CI_ATTIC_PUSH_TOKEN }}"
+            nix run nixpkgs#attic-client -- push home:home-cache --ignore-upstream-cache-filter -j 1 ./result


### PR DESCRIPTION
Why: attic cache pushes over tailscale occasionally timeout, and
with continue-on-error the whole step was silently skipped after a
single attempt, losing the cache write for that run.

What:
- wrap the attic login/push commands for both the gibson and darwin
  full-build jobs in nick-fields/retry
- retry up to 3 attempts with a 45 minute per-attempt timeout
