### PR TITLE
fix(attic-client): run attic-watch-store service as dedicated user

### DIFF
--- a/features/system/attic-client/_nixos.nix
+++ b/features/system/attic-client/_nixos.nix
@@ -1,6 +1,18 @@
-{ config, pkgs, ... }:
 {
-  sops.secrets."services/attic/token" = { };
+  config,
+  pkgs,
+  ...
+}:
+{
+  users.groups.attic-watch-store = { };
+  users.users.attic-watch-store = {
+    isSystemUser = true;
+    group = "attic-watch-store";
+  };
+
+  sops.secrets."services/attic/token" = {
+    owner = config.users.users.attic-watch-store.name;
+  };
 
   systemd.services.attic-watch-store = {
     description = "Push new Nix store paths to attic";
@@ -8,6 +20,8 @@
     after = [ "network-online.target" ];
     wants = [ "network-online.target" ];
     serviceConfig = {
+      User = "attic-watch-store";
+      Group = "attic-watch-store";
       Type = "simple";
       StateDirectory = "attic-watch-store";
       Environment = "HOME=%S/attic-watch-store";


### PR DESCRIPTION
Why: the attic-watch-store systemd service ran as root, giving it the
potential to cause a long-lived shared read lock against nix's big-lock
database, preventing system rebuilds and other tasks from completing
until the lock is released.

What:
- add a dedicated attic-watch-store system user and group
- own the sops-managed attic token secret by that user
- run the systemd service under the new user/group
