### PR TITLE
fix(doomemacs): add cmake and make to doom emacs deps

### DIFF
--- a/features/home/doomemacs/_module.nix
+++ b/features/home/doomemacs/_module.nix
@@ -47,6 +47,8 @@ mkMerge [
         imagemagick
         fd
         zstd
+        cmake
+        gnumake
       ];
 
       file."${config.xdg.configHome}/doom" = {


### PR DESCRIPTION
Why: doom emacs modules that build native components (e.g. vterm)
require cmake and make, which were missing from the home-manager
package set.

What:
- add cmake to doomemacs package list
- add gnumake to doomemacs package list
