### PR TITLE
fix(gibson): correct hyprland window rule field for game tag match

### DIFF
--- a/hosts/gibson/applications/hypr/hyprland.lua
+++ b/hosts/gibson/applications/hypr/hyprland.lua
@@ -178,7 +178,7 @@ return function(WS)
   hl.window_rule({ match = { class = "^(gamescope)$" }, no_blur = true, workspace = "name:" .. WS.WS3 })
   hl.window_rule({ match = { title = "^(007 First Light)$" }, no_blur = true, workspace = "name:" .. WS.WS3 })
   hl.window_rule({ match = { class = "^(steam_app_0)$" }, no_blur = true, workspace = "name:" .. WS.WS3 })
-  hl.window_rule({ match = { content = "game", fullscreen = true }, confine_pointer = true })
+  hl.window_rule({ match = { tag = "game", fullscreen = true }, confine_pointer = true })
 
   ------------------------------------------------------------------------
   -- WINDOW RULES: idle inhibit


### PR DESCRIPTION
Why: the game fullscreen window rule used a non-existent `content`
match field, so `confine_pointer` never applied to tagged game
windows.

What:
- change window_rule match key from `content` to `tag` for the
  fullscreen game rule in hyprland.lua
