### PR TITLE
chore(flake): weekly update (01/08/26)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -95,11 +95,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1784948311,
-        "narHash": "sha256-zXmyx6HuIjH0RQPV4VjVAXQttLyLDk55x9c3NmDke8c=",
+        "lastModified": 1785285785,
+        "narHash": "sha256-r1cMlvXjRVKe+uQ/GKwy4TpionpmbNgksFP2758D/MM=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "0d3cd1d6260b6f0ed232224c274c565407446fa1",
+        "rev": "da78262708d858861afbe1f68ea65fedda4054c4",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
     "doomemacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1784700822,
-        "narHash": "sha256-T4ycvZiNjHSWVKvQPdgDvKt/eQpjXKR9gjJ5pJD6GVM=",
+        "lastModified": 1785311599,
+        "narHash": "sha256-cmQ2/kRScuwyywxWbiofdlL/KCQL9txWQecYC63uf+k=",
         "owner": "doomemacs",
         "repo": "core",
-        "rev": "8a301d98d0d6d1aa7c54a8f8df48de7b2c886b2e",
+        "rev": "6ba99cb50cddc4441963a0ef68f971112ab4807e",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
     "doomemacs-modules": {
       "flake": false,
       "locked": {
-        "lastModified": 1784700508,
-        "narHash": "sha256-Z+ngNBXal5ENx3PnAFEj8VSuihL6aZbSuRjFoy6HBKQ=",
+        "lastModified": 1785313389,
+        "narHash": "sha256-hNl5bcSnorY/ms5IKtJ2/5/pjRxm0LhLSkJNO4vyVoo=",
         "owner": "doomemacs",
         "repo": "modules",
-        "rev": "28f09d8afe81fa47ab83020b072f0dfa2f79dbdb",
+        "rev": "6e891e44d5d2a1391a6ce1a6f2ad484f86bfd6e2",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1784949653,
-        "narHash": "sha256-1TfzsK7w7uITI3ntHwB+ogq3kDxP+aSDzNfAF/i5q/M=",
+        "lastModified": 1785555078,
+        "narHash": "sha256-xBn8X29zbHeDE2CvDjOYC48CF4E7UaEb5uGIs+99nXs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "32ac6e14639198b1b254c8742d9151b468d320e7",
+        "rev": "2ae92204d450a15f0e49b249621036c23b67414c",
         "type": "github"
       },
       "original": {
@@ -430,11 +430,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784913159,
-        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
+        "lastModified": 1785531816,
+        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
+        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
         "type": "github"
       },
       "original": {
@@ -488,11 +488,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784500460,
-        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
+        "lastModified": 1785389976,
+        "narHash": "sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
+        "rev": "15abb8c98f336cd8bd840d71059adebabe60bf04",
         "type": "github"
       },
       "original": {
@@ -509,11 +509,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1784949315,
-        "narHash": "sha256-DFb7pfxvQIzfj/UiET+jNesON0nt3+5pk11URu+Nqrc=",
+        "lastModified": 1785554838,
+        "narHash": "sha256-JyJODyGrRSmLmXpPrpTqorRRZNaB42BPwIDyKckjw1k=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "a3391389b07fc616f6cc301005013f64f9d4e7e3",
+        "rev": "74dcc474028b87a9cca116815c003b1b5b731eea",
         "type": "github"
       },
       "original": {
@@ -618,11 +618,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1784707089,
-        "narHash": "sha256-2V/6imsUgB7mPZlHY54oeVBRDoZbPKnvzwkAHUSSufk=",
+        "lastModified": 1785386831,
+        "narHash": "sha256-sPS3CaXH8RAT3FZRuy4VcV47iuYIWMMfa0GbyJKC3o4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3fe9581c9061c749abef42b6d4ee7b7c05c33fa",
+        "rev": "21ea275a7c46aef9d4d6ddc962e6d562e9d94183",
         "type": "github"
       },
       "original": {
@@ -634,11 +634,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1784707089,
-        "narHash": "sha256-2V/6imsUgB7mPZlHY54oeVBRDoZbPKnvzwkAHUSSufk=",
+        "lastModified": 1785491804,
+        "narHash": "sha256-p00vplVOyfKGlhju0+eGGPAxyYYKaY0lpyuoHLFIx2Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b3fe9581c9061c749abef42b6d4ee7b7c05c33fa",
+        "rev": "5b4f72e1705a63aace42900610c4db82cb4af0ec",
         "type": "github"
       },
       "original": {
@@ -666,11 +666,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {
@@ -746,11 +746,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1784364478,
-        "narHash": "sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY=",
+        "lastModified": 1784872115,
+        "narHash": "sha256-THPEF2po0fsoH8gNtp+Ae0XFDJH3N/ol7xO3v6VMTJU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20535e48e12c86043b577b8518234ff5dbb26957",
+        "rev": "335f0738cb2fa9708f3f428e39d2eae975d1338d",
         "type": "github"
       },
       "original": {
@@ -762,11 +762,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {

--- a/hosts/gibson/overlays/audit.nix
+++ b/hosts/gibson/overlays/audit.nix
@@ -5,19 +5,6 @@
 # Coupled overlays with no independent removal condition: add `# audit-exempt` inside their block in default.nix.
 
 {
-  bitwarden-desktop = {
-    description = "Override electron_39 with electron_39-bin to unblock bitwarden-desktop build";
-    notes = "Also remove permittedInsecurePackages entry from hosts/gibson/system.nix.";
-    strategy = "nixpkgs-issue";
-    systems = [ "x86_64-linux" ];
-    trackingIssues = [
-      {
-        number = 526914;
-        repo = "NixOS/nixpkgs";
-      }
-    ];
-  };
-
   mpv-unwrapped = {
     description = "Backport fence-sync fix milestoned for mpv 0.42.0";
     notes = "mpv override is a coupled removal — remove both blocks together.";

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -45,13 +45,6 @@
         inherit (final) mpv-unwrapped;
       };
 
-      # upstream nixpkgs issue - remove when bitwarden-desktop bumps electron
-      # TODO: Monitor this for upstream: https://github.com/NixOS/nixpkgs/issues/526914
-      # Also remove permittedInsecurePackages from hosts/gibson/system.nix
-      bitwarden-desktop = prev.bitwarden-desktop.override {
-        electron_39 = final.electron_39-bin;
-      };
-
       # TODO: Monitor new waybar package releases
       # Associated PR is merged; requires a new release.
       waybar = prev.waybar.overrideAttrs (old: {

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -354,10 +354,6 @@ in
     };
   };
 
-  # upstream nixpkgs issue - remove when bitwarden-desktop bumps electron
-  # TODO: Monitor this for upstream: https://github.com/NixOS/nixpkgs/issues/526914
-  nixpkgs.config.permittedInsecurePackages = [ "electron-39.8.10" ];
-
   hardware = {
     i2c.enable = true;
     cpu.amd.updateMicrocode = true;


### PR DESCRIPTION
Automated weekly `flake.lock` update.

Flake lock file updates:

• Updated input 'claude-code-nix':
    'github:sadjow/claude-code-nix/0d3cd1d' (2026-07-25)
  → 'github:sadjow/claude-code-nix/da78262' (2026-07-29)
• Updated input 'doomemacs':
    'github:doomemacs/core/8a301d9' (2026-07-22)
  → 'github:doomemacs/core/6ba99cb' (2026-07-29)
• Updated input 'doomemacs-modules':
    'github:doomemacs/modules/28f09d8' (2026-07-22)
  → 'github:doomemacs/modules/6e891e4' (2026-07-29)
• Updated input 'emacs-overlay':
    'github:nix-community/emacs-overlay/32ac6e1' (2026-07-25)
  → 'github:nix-community/emacs-overlay/2ae9220' (2026-08-01)
• Updated input 'emacs-overlay/nixpkgs':
    'github:NixOS/nixpkgs/e2587ca' (2026-07-23)
  → 'github:NixOS/nixpkgs/1559d3d' (2026-07-30)
• Updated input 'emacs-overlay/nixpkgs-stable':
    'github:NixOS/nixpkgs/b3fe958' (2026-07-22)
  → 'github:NixOS/nixpkgs/21ea275' (2026-07-30)
• Updated input 'home-manager':
    'github:nix-community/home-manager/079a3b5' (2026-07-24)
  → 'github:nix-community/home-manager/bf9ce9f' (2026-07-31)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/57a3171' (2026-07-19)
  → 'github:LnL7/nix-darwin/15abb8c' (2026-07-30)
• Updated input 'nix-gaming':
    'github:fufexan/nix-gaming/a339138' (2026-07-25)
  → 'github:fufexan/nix-gaming/74dcc47' (2026-08-01)
• Updated input 'nix-gaming/nixpkgs':
    'github:NixOS/nixpkgs/20535e4' (2026-07-18)
  → 'github:NixOS/nixpkgs/335f073' (2026-07-24)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/e2587ca' (2026-07-23)
  → 'github:NixOS/nixpkgs/1559d3d' (2026-07-30)
• Updated input 'nixpkgs-stable':
    'github:nixos/nixpkgs/b3fe958' (2026-07-22)
  → 'github:nixos/nixpkgs/5b4f72e' (2026-07-31)