### PR TITLE
fix(gibson): remove bitwarden-desktop electron override and audit entry

### DIFF
--- a/hosts/gibson/overlays/audit.nix
+++ b/hosts/gibson/overlays/audit.nix
@@ -5,19 +5,6 @@
 # Coupled overlays with no independent removal condition: add `# audit-exempt` inside their block in default.nix.
 
 {
-  bitwarden-desktop = {
-    description = "Override electron_39 with electron_39-bin to unblock bitwarden-desktop build";
-    notes = "Also remove permittedInsecurePackages entry from hosts/gibson/system.nix.";
-    strategy = "nixpkgs-issue";
-    systems = [ "x86_64-linux" ];
-    trackingIssues = [
-      {
-        number = 526914;
-        repo = "NixOS/nixpkgs";
-      }
-    ];
-  };
-
   mpv-unwrapped = {
     description = "Backport fence-sync fix milestoned for mpv 0.42.0";
     notes = "mpv override is a coupled removal — remove both blocks together.";

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -45,13 +45,6 @@
         inherit (final) mpv-unwrapped;
       };
 
-      # upstream nixpkgs issue - remove when bitwarden-desktop bumps electron
-      # TODO: Monitor this for upstream: https://github.com/NixOS/nixpkgs/issues/526914
-      # Also remove permittedInsecurePackages from hosts/gibson/system.nix
-      bitwarden-desktop = prev.bitwarden-desktop.override {
-        electron_39 = final.electron_39-bin;
-      };
-
       # TODO: Monitor new waybar package releases
       # Associated PR is merged; requires a new release.
       waybar = prev.waybar.overrideAttrs (old: {

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -354,10 +354,6 @@ in
     };
   };
 
-  # upstream nixpkgs issue - remove when bitwarden-desktop bumps electron
-  # TODO: Monitor this for upstream: https://github.com/NixOS/nixpkgs/issues/526914
-  nixpkgs.config.permittedInsecurePackages = [ "electron-39.8.10" ];
-
   hardware = {
     i2c.enable = true;
     cpu.amd.updateMicrocode = true;


### PR DESCRIPTION
Why: bitwarden-desktop has bumped its electron dependency upstream,
so the electron_39-bin override and the associated insecure package
allowance are no longer needed.

What:
- drop bitwarden-desktop electron_39-bin override from overlays
- remove bitwarden-desktop entry from overlay audit registry
- remove permittedInsecurePackages entry for electron-39.8.10
