### PR TITLE
chore(gibson): drop lutris from packages and cleanup script

### DIFF
--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -139,7 +139,6 @@ in
       libmodule
       linux-firmware
       lm_sensors
-      lutris
       nixos-container
       nix-prefetch-github
       openssl

--- a/pkgs/game-cleanup/default.nix
+++ b/pkgs/game-cleanup/default.nix
@@ -8,6 +8,6 @@ pkgs.writeShellApplication {
   ];
   text = ''
     # shellcheck disable=SC2009
-    for i in $(ps aux | grep -i "wine\|gamescope\|lutris-wrapper\|defunct\|\.exe" | grep -iv grep | awk '{print $2}'); do kill -9 "$i"; done
+    for i in $(ps aux | grep -i "wine\|gamescope\|defunct\|\.exe" | grep -iv grep | awk '{print $2}'); do kill -9 "$i"; done
   '';
 }


### PR DESCRIPTION
Why: lutris is no longer used on gibson, so keep the package
list and the game-cleanup process matcher in sync with that.

What:
- remove lutris from the gibson system packages
- drop the lutris-wrapper pattern from game-cleanup's kill matcher
