### PR TITLE
refactor(theming): further stylix improvements + add mako

### DIFF
--- a/features/home/mako/_module.nix
+++ b/features/home/mako/_module.nix
@@ -20,10 +20,7 @@ in
     services.mako = {
       enable = true;
       settings = {
-        background-color = "#282A36";
-        text-color = "#FFFFFF";
         padding = "10";
-        font = "Tamzen 12";
         layer = "overlay";
         anchor = "top-right";
         margin = "11";
@@ -34,17 +31,11 @@ in
         height = 170;
         max-icon-size = 32;
 
-        "urgency=low" = {
-          border-color = "#BD93F9";
-        };
-
         "urgency=normal" = {
-          border-color = "#BD93F9";
           on-notify = "exec ${pkgs.vlc}/bin/cvlc --play-and-exit ${config.xdg.configHome}/mako/notification.wav";
         };
 
-        "urgency=high" = {
-          border-color = "#FF5555";
+        "urgency=critical" = {
           on-notify = "exec ${pkgs.vlc}/bin/cvlc --play-and-exit ${config.xdg.configHome}/mako/notification.wav";
         };
 

--- a/features/home/stylix/_module.nix
+++ b/features/home/stylix/_module.nix
@@ -1,13 +1,14 @@
 {
   pkgs,
+  lib,
   ...
 }:
 
 {
   stylix = {
     enable = true;
-    autoEnable = false;
-    base16Scheme = "${pkgs.base16-schemes}/share/themes/dracula.yaml";
+    autoEnable = true;
+    base16Scheme = "${pkgs.base16-schemes}/share/themes/tokyo-city-dark.yaml";
     polarity = "dark";
 
     cursor = {
@@ -21,16 +22,32 @@
         package = pkgs.noto-fonts;
         name = "Noto Sans Mono";
       };
-      sizes.terminal = 10;
+      sizes = {
+        terminal = 10; # already set
+        applications = 12; # qutebrowser UI — bump if 12pt is still too small for you
+        desktop = 13; # waybar — raise from the 10pt default
+        popups = 12; # mako, rofi
+      };
     };
 
     opacity.terminal = 0.87;
 
-    targets = {
+    targets = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
       gtk.enable = true;
-      qutebrowser.enable = true;
-      kitty.enable = true;
+      kitty = {
+        enable = true;
+        fonts.override = {
+          monospace = {
+            package = pkgs.hack-font;
+            name = "Hack";
+          };
+        };
+      };
       rofi.enable = true;
+      mako.enable = true;
+      fuzzel.enable = false;
+      hyprlock.enable = false;
+      waybar.enable = false;
     };
   };
 }

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -158,6 +158,7 @@ in
       GSETTINGS_BACKEND = "keyfile";
       GBM_BACKEND = "nvidia-drm";
       NVD_BACKEND = "direct";
+      GTK_THEME = "adw-gtk3:dark";
       LIBVA_DRIVER_NAME = "nvidia";
       WLR_NO_HARDWARE_CURSORS = "1";
       QTWEBENGINE_FORCE_USE_GBM = "1";


### PR DESCRIPTION
Why: the initial stylix config implementation did not include mako and
was configured to be linux specific. This sets linux options and turns
on autoEnable in order to allow darwin to leverage stylix theming for
the applications it uses (.e.g. Ghostty/Qutebrowser). It also includes a
minor inherent change to mako config.

What:
- drop mako's hardcoded background/text colors and font now that
  stylix autoEnable supplies them
- rename mako's urgency=high block to urgency=critical to match
  mako's actual urgency levels
- enable stylix autoEnable, switch to the tokyo-city-dark scheme,
  and add per-target font sizes for applications/desktop/popups
- wrap stylix targets in lib.mkIf isLinux, add a kitty font
  override, enable the mako target, drop qutebrowser as its
  autoEnable'd, and explicitly disable fuzzel/hyprlock/waybar
- set GTK_THEME=adw-gtk3:dark in gibson's session environment as the
  removal of this earlier caused a regression with title bars being
  light themed

Notes: fuzzel/hyprlock/waybar stylix targets are disabled for now
and still need their own theming pass.
