### PR TITLE
fix(gibson): resolve bitwarden-desktop secure key container issue

### DIFF
--- a/hosts/gibson/applications/hypr/hyprland.lua
+++ b/hosts/gibson/applications/hypr/hyprland.lua
@@ -153,7 +153,7 @@ return function(WS)
   hl.window_rule({ match = { class = "^(cider)$" }, workspace = "name:" .. WS.WS6 })
   hl.window_rule({ match = { class = "^(.*)(mpv)(.*)$" }, workspace = "name:" .. WS.WS6, fullscreen = true })
   hl.window_rule({ match = { class = "^(.*)(org.jellyfin.JellyfinDesktop)(.*)$" }, workspace = "name:" .. WS.WS6 })
-  hl.window_rule({ match = { class = "^(Bitwarden)$" }, workspace = "name:" .. WS.WS7 })
+  hl.window_rule({ match = { class = "^(bitwarden)$" }, workspace = "name:" .. WS.WS7 })
   hl.window_rule({ match = { class = "^(.*)(obs)(.*)$" }, workspace = "name:" .. WS.WS8 })
 
   ------------------------------------------------------------------------

--- a/hosts/gibson/home.nix
+++ b/hosts/gibson/home.nix
@@ -31,7 +31,6 @@
       libnotify
       fastfetch
       rivalcfg
-      rofi-rbw-wayland
       signal-desktop
       spice-gtk
       wl-clipboard

--- a/hosts/gibson/overlays/default.nix
+++ b/hosts/gibson/overlays/default.nix
@@ -31,6 +31,16 @@
           ];
       };
 
+      # TODO: Monitor new bitwarden package releases
+      # Upstream issue has no permanent fix yet:
+      # https://github.com/bitwarden/clients/issues/21661
+      bitwarden-desktop = prev.bitwarden-desktop.overrideAttrs (old: {
+        postFixup = (old.postFixup or "") + ''
+          wrapProgram $out/bin/bitwarden \
+            --set SECURE_KEY_CONTAINER_BACKEND keyctl
+        '';
+      });
+
       # ── Temporary overlays ─────────────────────────────────────────
       # TODO: Monitor new mpv package releases
       # Associated PR is merged; requires a new release.
@@ -58,6 +68,5 @@
         nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.catch2_3 ];
       });
     })
-
   ];
 }

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -155,13 +155,12 @@ in
       DOCKER_HOST = "unix://\${XDG_RUNTIME_DIR}/podman/podman.sock";
       ENABLE_DPMS = "1";
       ENABLE_DDC = "1";
-      GSETTINGS_BACKEND = "keyfile";
       GBM_BACKEND = "nvidia-drm";
-      NVD_BACKEND = "direct";
+      GSETTINGS_BACKEND = "keyfile";
       GTK_THEME = "adw-gtk3:dark";
       LIBVA_DRIVER_NAME = "nvidia";
+      NVD_BACKEND = "direct";
       WLR_NO_HARDWARE_CURSORS = "1";
-      QTWEBENGINE_FORCE_USE_GBM = "1";
       __GLX_VENDOR_LIBRARY_NAME = "nvidia";
       __GL_MaxFramesAllowed = "1";
       __GL_GSYNC_ALLOWED = "1";


### PR DESCRIPTION
Why: bitwarden-desktop fails to unlock its secure key container on
NixOS; upstream has no permanent fix yet (see linked issue). This causes
issues with hibernation locks meaning the system wont hibernate properly

What:
- overlay bitwarden-desktop to wrap the binary with
  SECURE_KEY_CONTAINER_BACKEND=keyctl
- fix hyprland window rule class match (app now reports lowercase
  "bitwarden")
- drop rofi-rbw-wayland, no longer needed; fuzzel is used by the system.
- drop QTWEBENGINE_FORCE_USE_GBM workaround and reorder env vars in
  system.nix
