### PR TITLE
fix(registry): disable stylix overlays in shared home-manager module

### DIFF
--- a/flake/parts/hosts/registry.nix
+++ b/flake/parts/hosts/registry.nix
@@ -111,7 +111,10 @@ in
                 # which matches unstable. The version mismatch warning fires as a
                 # false positive because pkgs-stable (26.05) is also in scope.
                 # Suppressing here rather than per-host since it applies globally.
-                { home.enableNixpkgsReleaseCheck = false; }
+                {
+                  home.enableNixpkgsReleaseCheck = false;
+                  stylix.overlays.enable = lib.mkForce false;
+                }
               ];
 
               users.${host.vars.username} = {


### PR DESCRIPTION
Why: stylix.overlays.enable was left on the home-manager side after
the recent stylix refactor, causing overlays to apply twice since
they're already handled elsewhere. Setting it in the global
sharedModules keeps the fix host-agnostic, same as the existing
release-check suppression above it.

What:
- force-disable stylix.overlays.enable in the shared home-manager
  module in flake/parts/hosts/registry.nix

Notes: applies globally to every host via sharedModules, so no
per-host overrides should be needed; revisit if a host later needs
home-manager-driven stylix overlays specifically.
