### PR TITLE
fix(darwin): register stylix home-manager module for macbook

### DIFF
--- a/profiles/home/darwin.nix
+++ b/profiles/home/darwin.nix
@@ -1,6 +1,7 @@
 { inputs, ... }:
 {
   imports = [
+    inputs.stylix.homeModules.stylix
     inputs.mac-app-util.homeManagerModules.default
     inputs.self.modules.homeManager.claude-code
     inputs.self.modules.homeManager.doomemacs
@@ -9,6 +10,7 @@
     inputs.self.modules.homeManager.qutebrowser
     inputs.self.modules.homeManager.nix-settings
     inputs.self.modules.homeManager.sops-nix
+    inputs.self.modules.homeManager.stylix
     inputs.self.modules.homeManager.symlinks
     inputs.self.modules.homeManager.syncthing
   ];


### PR DESCRIPTION
Why: Enable consistent theming for some darwin stuffs! Mainly
qutebrowser/ghostty

What:
- import inputs.stylix.homeModules.stylix
- import inputs.self.modules.homeManager.stylix
