### PR TITLE
chore(gibson): remove sddm x11 configuration

### DIFF
--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -268,23 +268,10 @@ in
       defaultSession = "hyprland";
       sddm = {
         enable = true;
+        wayland.enable = true;
         package = pkgs.kdePackages.sddm;
         extraPackages = with pkgs; [ kdePackages.qtmultimedia ];
         theme = "sddm-astronaut-theme";
-        wayland = {
-          enable = false;
-        };
-        settings = {
-          X11 = {
-            DisplayCommand = "${pkgs.writeShellScript "sddm-xsetup" ''
-              #!/bin/sh
-              ${pkgs.xrandr}/bin/xrandr \
-                --output DP-1 --primary --auto \
-                --output HDMI-A-1 --off \
-                --output DP-2 --off
-            ''}";
-          };
-        };
       };
     };
 


### PR DESCRIPTION
Why: sddm was configured to use to X11 but never actually improved
multi-monitor usage, so its been reverted back to wayland

What:
- re-add wayland.enable = true for sddm
- remove the xrandr-based X11 DisplayCommand hardcoding monitor
  layout
