### PR TITLE
fix(media): add in colourspace hint option for mpv

### DIFF
--- a/features/home/media/_module.nix
+++ b/features/home/media/_module.nix
@@ -45,6 +45,7 @@
         volume = 90;
 
         vd-lavc-dr = "no";
+        target-colorspace-hint-mode = "source";
       };
 
       profiles.wallpaper = {


### PR DESCRIPTION
Why: It turns out mpv can support HDR output if the display/compositor
supports it; I've added a colourspace-hint option to the media-specific
mpv config that allows it to use a source (i.e. the compositor) to
handle HDR conversion. Hyprland is configured to leverage colour management.

What:
- set target-colorspace-hint-mode to "source" in mpv profile config
