### PR TITLE
feat(stylix): manage ghostty theming via stylix on darwin

### DIFF
--- a/features/home/ghostty/_module.nix
+++ b/features/home/ghostty/_module.nix
@@ -10,8 +10,6 @@
       enableZshIntegration = true;
       installVimSyntax = true;
       settings = {
-        theme = "dracula";
-        font-size = 14;
         macos-option-as-alt = "left";
       };
     };

--- a/features/home/stylix/_module.nix
+++ b/features/home/stylix/_module.nix
@@ -32,22 +32,38 @@
 
     opacity.terminal = 0.87;
 
-    targets = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
-      gtk.enable = true;
-      kitty = {
-        enable = true;
-        fonts.override = {
-          monospace = {
-            package = pkgs.hack-font;
-            name = "Hack";
+    targets = lib.mkMerge [
+      (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+        ghostty = {
+          colors.override = {
+            base05 = "d8e2ec";
+          };
+          fonts.override = {
+            monospace = {
+              package = pkgs.hack-font;
+              name = "Hack";
+            };
+            sizes.terminal = 11;
           };
         };
-      };
-      rofi.enable = true;
-      mako.enable = true;
-      fuzzel.enable = false;
-      hyprlock.enable = false;
-      waybar.enable = false;
-    };
+      })
+      (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
+        gtk.enable = true;
+        kitty = {
+          enable = true;
+          fonts.override = {
+            monospace = {
+              package = pkgs.hack-font;
+              name = "Hack";
+            };
+          };
+        };
+        rofi.enable = true;
+        mako.enable = true;
+        fuzzel.enable = false;
+        hyprlock.enable = false;
+        waybar.enable = false;
+      })
+    ];
   };
 }


### PR DESCRIPTION
Why: stylix targets were scoped to Linux only via lib.mkIf, so ghostty
on macOS had no stylix-managed theme and needed hardcoded settings
instead.

What:
- split stylix targets into darwin/linux branches with lib.mkMerge
- enable stylix ghostty target on darwin with color and font overrides
- drop the now-redundant theme/font-size overrides from the ghostty
  module
