### PR TITLE
feat(stylix): theme qutebrowser fonts via stylix targets

### DIFF
--- a/features/home/stylix/_module.nix
+++ b/features/home/stylix/_module.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   lib,
   ...
@@ -33,6 +34,17 @@
     opacity.terminal = 0.87;
 
     targets = lib.mkMerge [
+      (lib.mkIf config.programs.qutebrowser.enable {
+        qutebrowser = {
+          fonts.override = {
+            sansSerif = {
+              package = pkgs.hack-font;
+              name = "Hack";
+            };
+          };
+        };
+      })
+
       (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
         ghostty = {
           colors.override = {
@@ -47,6 +59,7 @@
           };
         };
       })
+
       (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
         gtk.enable = true;
         kitty = {


### PR DESCRIPTION
Why: qutebrowser wasn't fully wired into stylix's target list, so it
fell back to its own defaults instead of the shared theme fonts.

What:
- add config to module args to check
  programs.qutebrowser.enable
- add a qutebrowser targets.mkIf block that overrides the
  sans-serif font to hack-font
