### PR TITLE
feat(system): migrate sddm into a feature module

### DIFF
--- a/features/system/sddm/_module.nix
+++ b/features/system/sddm/_module.nix
@@ -1,0 +1,48 @@
+# features/system/core/sddm/module.nix
+{
+  inputs,
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.features.system.sddm;
+
+  baseTheme = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.sddm-astronaut-theme;
+  sddmTheme = if cfg.theme == null then baseTheme else baseTheme.override { inherit (cfg) theme; };
+in
+{
+  options.features.system.sddm = {
+    theme = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "sddm-astronaut-theme package variant to build; null defers to the package's own default.";
+    };
+    kwinOutputConfig = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Path to a host-specific kwinoutputconfig.json pinning the greeter's monitor layout; null leaves kwin's auto-detected default (clones to all outputs).";
+    };
+  };
+
+  config = {
+    environment.systemPackages = [ sddmTheme ];
+    fonts.packages = [ (toString sddmTheme + "/share/fonts") ];
+
+    services.displayManager.sddm = {
+      enable = true;
+      wayland = {
+        enable = true;
+        compositor = "kwin";
+      };
+      package = pkgs.kdePackages.sddm;
+      extraPackages = with pkgs; [ kdePackages.qtmultimedia ];
+      theme = "sddm-astronaut-theme";
+    };
+
+    systemd.tmpfiles.rules = lib.optionals (cfg.kwinOutputConfig != null) [
+      "f+ /var/lib/sddm/.config/kwinoutputconfig.json 644 sddm sddm - ${builtins.toJSON (builtins.fromJSON (builtins.readFile cfg.kwinOutputConfig))}"
+    ];
+  };
+}

--- a/features/system/sddm/default.nix
+++ b/features/system/sddm/default.nix
@@ -1,0 +1,3 @@
+_: {
+  flake.modules.nixos.sddm = ./_module.nix;
+}

--- a/hosts/gibson/applications/sddm/kwinoutputconfig.json
+++ b/hosts/gibson/applications/sddm/kwinoutputconfig.json
@@ -1,0 +1,200 @@
+[
+    {
+        "data": [
+            {
+                "abmLevel": 0,
+                "allowDdcCi": true,
+                "allowSdrSoftwareBrightness": true,
+                "autoBrightnessCurve": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "autoRotation": "InTabletMode",
+                "automaticBrightness": false,
+                "brightness": 1,
+                "colorPowerTradeoff": "PreferEfficiency",
+                "colorProfileSource": "sRGB",
+                "connectorName": "HDMI-A-1",
+                "customModes": [
+                ],
+                "detectedDdcCi": false,
+                "edidHash": "3c6db94ec01bb4c168ca66d81be361a8",
+                "edidIdentifier": "BNQ 30926 21573 3 2013 0",
+                "edrPolicy": "always",
+                "hdrColorProfileSource": "EDID",
+                "hdrIccProfilePath": "",
+                "highDynamicRange": false,
+                "iccProfilePath": "",
+                "maxBitsPerColor": 0,
+                "mode": {
+                    "flags": 1,
+                    "height": 1080,
+                    "refreshRate": 60000,
+                    "width": 1920
+                },
+                "overscan": 0,
+                "rgbRange": "Automatic",
+                "scale": 1,
+                "sdrBrightness": 200,
+                "sdrGamutWideness": 0,
+                "sharpness": 0,
+                "transform": "Normal",
+                "uuid": "28b9f02f-4c58-4df7-97d6-d6f19de72d76",
+                "vrrPolicy": "Never",
+                "wideColorGamut": false
+            },
+            {
+                "abmLevel": 0,
+                "allowDdcCi": true,
+                "allowSdrSoftwareBrightness": true,
+                "autoBrightnessCurve": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "autoRotation": "InTabletMode",
+                "automaticBrightness": false,
+                "brightness": 1,
+                "colorPowerTradeoff": "PreferEfficiency",
+                "colorProfileSource": "sRGB",
+                "connectorName": "DP-1",
+                "customModes": [
+                ],
+                "detectedDdcCi": false,
+                "edidHash": "a5293fa4767df7f263098c09bebdab25",
+                "edidIdentifier": "BNQ 32630 21573 23 2020 0",
+                "edrPolicy": "always",
+                "hdrColorProfileSource": "EDID",
+                "hdrIccProfilePath": "",
+                "highDynamicRange": false,
+                "iccProfilePath": "",
+                "maxBitsPerColor": 0,
+                "mode": {
+                    "flags": 1,
+                    "height": 1440,
+                    "refreshRate": 143999,
+                    "width": 2560
+                },
+                "overscan": 0,
+                "rgbRange": "Automatic",
+                "scale": 1,
+                "sdrBrightness": 417,
+                "sdrGamutWideness": 0,
+                "sharpness": 0,
+                "transform": "Normal",
+                "uuid": "c21f6eb2-0757-4f4b-8e62-72d9e4b3658e",
+                "vrrPolicy": "Never",
+                "wideColorGamut": false
+            },
+            {
+                "abmLevel": 0,
+                "allowDdcCi": true,
+                "allowSdrSoftwareBrightness": true,
+                "autoBrightnessCurve": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "autoRotation": "InTabletMode",
+                "automaticBrightness": false,
+                "brightness": 1,
+                "colorPowerTradeoff": "PreferEfficiency",
+                "colorProfileSource": "sRGB",
+                "connectorName": "DP-2",
+                "customModes": [
+                ],
+                "detectedDdcCi": false,
+                "edidHash": "59b457454cf244f4df7f6755bdf0f914",
+                "edidIdentifier": "ACI 9380 16843009 24 2016 0",
+                "edrPolicy": "always",
+                "hdrColorProfileSource": "EDID",
+                "hdrIccProfilePath": "",
+                "highDynamicRange": false,
+                "iccProfilePath": "",
+                "maxBitsPerColor": 0,
+                "mode": {
+                    "flags": 0,
+                    "height": 1080,
+                    "refreshRate": 144001,
+                    "width": 1920
+                },
+                "overscan": 0,
+                "rgbRange": "Automatic",
+                "scale": 1,
+                "sdrBrightness": 200,
+                "sdrGamutWideness": 0,
+                "sharpness": 0,
+                "transform": "Normal",
+                "uuid": "9c1f01a1-4bf5-412e-85fb-1daeac32c7f3",
+                "vrrPolicy": "Never",
+                "wideColorGamut": false
+            }
+        ],
+        "name": "outputs"
+    },
+    {
+        "data": [
+            {
+                "lidClosed": false,
+                "outputs": [
+                    {
+                        "enabled": false,
+                        "outputIndex": 0,
+                        "position": {
+                            "x": 0,
+                            "y": 0
+                        },
+                        "priority": 0,
+                        "replicationSource": ""
+                    },
+                    {
+                        "enabled": true,
+                        "outputIndex": 1,
+                        "position": {
+                            "x": 1920,
+                            "y": 0
+                        },
+                        "priority": 1,
+                        "replicationSource": ""
+                    },
+                    {
+                        "enabled": false,
+                        "outputIndex": 2,
+                        "position": {
+                            "x": 4480,
+                            "y": 0
+                        },
+                        "priority": 2,
+                        "replicationSource": ""
+                    }
+                ]
+            }
+        ],
+        "name": "setups"
+    }
+]

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -7,11 +7,6 @@
   vars,
   ...
 }:
-let
-  sddmTheme = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.sddm-astronaut-theme.override {
-    theme = "post-apocalyptic_hacker";
-  };
-in
 {
   imports = [
     ./hardware-configuration.nix
@@ -90,7 +85,6 @@ in
     tamzen
     font-awesome
     material-design-icons
-    (toString sddmTheme + "/share/fonts")
 
     (google-fonts.override {
       fonts = [
@@ -143,7 +137,6 @@ in
       nix-prefetch-github
       openssl
       pulseaudio
-      sddmTheme
       v4l-utils
       vim
       xdg-utils
@@ -266,13 +259,6 @@ in
 
     displayManager = {
       defaultSession = "hyprland";
-      sddm = {
-        enable = true;
-        wayland.enable = true;
-        package = pkgs.kdePackages.sddm;
-        extraPackages = with pkgs; [ kdePackages.qtmultimedia ];
-        theme = "sddm-astronaut-theme";
-      };
     };
 
     xserver = {
@@ -366,5 +352,11 @@ in
     };
 
   };
+
+  features.system.sddm = {
+    theme = "post-apocalyptic_hacker";
+    kwinOutputConfig = ./applications/sddm/kwinoutputconfig.json;
+  };
+
   system.stateVersion = "23.11"; # Did you read the comment?
 }

--- a/profiles/system/nixos.nix
+++ b/profiles/system/nixos.nix
@@ -9,6 +9,7 @@
     inputs.self.modules.nixos.locale
     inputs.self.modules.nixos.nix-settings
     inputs.self.modules.nixos.overlays
+    inputs.self.modules.nixos.sddm
     inputs.self.modules.nixos.security
     inputs.self.modules.nixos.sops-nix
     inputs.self.modules.nixos.tailscale


### PR DESCRIPTION
Why: sddm setup was hardcoded in hosts/gibson/system.nix, and the kwin
greeter was not configured for the host's monitor layout, defaulting to
cloning across all outputs.

What:
- extract sddm theming/config into a reusable features.system.sddm
  module with theme and kwinOutputConfig options
- wire the new module into profiles/system/nixos.nix
- pin gibson's sddm theme and kwinoutputconfig.json via the new
  options, dropping the inline sddmTheme let-binding
