### PR TITLE
fix(yubikey): disable pcscd auto-restart to avoid resume race

### DIFF
--- a/features/system/core/yubikey/_module.nix
+++ b/features/system/core/yubikey/_module.nix
@@ -3,6 +3,7 @@
   pkgs,
   vars,
   hostname,
+  lib,
   ...
 }:
 {
@@ -31,15 +32,20 @@
     plugins = [ pkgs.ccid ];
   };
 
-  systemd.services.pcscd-resume = {
-    description = "Restart pcscd after hibernate resume";
-    wantedBy = [ "hibernate.target" ];
-    after = [ "hibernate.target" ];
-    script = ''
-      sleep 1
-      ${pkgs.systemd}/bin/systemctl restart pcscd
-    '';
-    serviceConfig.Type = "oneshot";
+  systemd = {
+    services = {
+      pcscd-resume = {
+        description = "Restart pcscd after hibernate resume";
+        wantedBy = [ "hibernate.target" ];
+        after = [ "hibernate.target" ];
+        script = ''
+          sleep 1
+          ${pkgs.systemd}/bin/systemctl restart pcscd
+        '';
+        serviceConfig.Type = "oneshot";
+      };
+      pcscd.serviceConfig.Restart = lib.mkForce "no";
+    };
   };
 
   services.udev.packages = with pkgs; [


### PR DESCRIPTION
Why: pcscd's default systemd Restart policy could kick in and race
against the pcscd-resume oneshot unit, undermining the deliberate
restart-after-hibernate workaround.

What:
- force pcscd's serviceConfig.Restart to "no" via lib.mkForce
- nest pcscd-resume under systemd.services alongside the new
  pcscd override

Notes: lib added to the module's function arguments to support
mkForce.
