### PR TITLE
feat(gibson): switch logout keybind to hyprshutdown helper

### DIFF
--- a/features/home/hypr/_hyprland.nix
+++ b/features/home/hypr/_hyprland.nix
@@ -15,6 +15,8 @@ in
       # Shared hyprland configuration
       xdg.configFile."hypr/${hostname}.lua".source = hyprConfig;
 
+      home.packages = with pkgs; [ hyprshutdown ];
+
       wayland.windowManager.hyprland = {
         enable = true;
         sourceFirst = false;

--- a/hosts/gibson/applications/hypr/hyprland.lua
+++ b/hosts/gibson/applications/hypr/hyprland.lua
@@ -61,7 +61,7 @@ return function(WS)
   hl.bind("SUPER + mouse:273", hl.dsp.window.resize(), { mouse = true })
   hl.bind("SUPER + F", hl.dsp.window.fullscreen())
   hl.bind("SUPER + SHIFT + Q", hl.dsp.window.close())
-  hl.bind("SUPER + SHIFT + C", hl.dsp.exit())
+  hl.bind("SUPER + SHIFT + C", hl.dsp.exec_cmd("command -v hyprshutdown >/dev/null 2>&1 && hyprshutdown --vt 1 || hyprctl dispatch 'hl.dsp.exit()'"))
   hl.bind("SUPER + SHIFT + SPACE", hl.dsp.window.float({ action = "toggle" }))
 
   hl.bind("SUPER + h", hl.dsp.focus({ direction = "l" }))

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -170,6 +170,17 @@
   security = {
     polkit.enable = true;
     rtkit.enable = true;
+    sudo.extraRules = [
+      {
+        users = [ vars.username ];
+        commands = [
+          {
+            command = "/run/current-system/sw/bin/chvt";
+            options = [ "NOPASSWD" ];
+          }
+        ];
+      }
+    ];
   };
 
   # List services that you want to enable:


### PR DESCRIPTION
Why: SUPER+SHIFT+C called hl.dsp.exit(), which just tears down the
Hyprland session instead of performing a full system shutdown/logout

What:
- add hyprshutdown package to the shared home hyprland module so its
  included by default
- rebind SUPER+SHIFT+C to run `hyprshutdown --vt 1`, falling back to
  hl.dsp.exit() if the binary isn't present
- grant passwordless sudo on chvt so hyprshutdown can switch VT
  before shutdown
