### PR TITLE
fix(stylix): use tamzen font for mako notifications

### DIFF
--- a/features/home/stylix/_module.nix
+++ b/features/home/stylix/_module.nix
@@ -72,7 +72,15 @@
           };
         };
         rofi.enable = true;
-        mako.enable = true;
+        mako = {
+          enable = true;
+          fonts.override = {
+            sansSerif = {
+              package = pkgs.tamzen;
+              name = "Tamzen";
+            };
+          };
+        };
         fuzzel.enable = false;
         hyprlock.enable = false;
         waybar.enable = false;


### PR DESCRIPTION
Why: mako was using the stylix default font instead of matching the
rest of the desktop's typeface choice

What:
- override mako's sansSerif font to pkgs.tamzen "Tamzen"

Notes: This matches the mako font config that was in place before the
switch to stylix
