### PR TITLE
feat(qutebrowser): pin to unstable fork to add FIDO2 support

### DIFF
--- a/hosts/macbook/overlays/audit.nix
+++ b/hosts/macbook/overlays/audit.nix
@@ -17,4 +17,15 @@
     ];
     notes = "COUPLED REMOVAL: also remove qtwebengine-fix flake input from flake.nix and the qtPinnedPkgs let-binding in hosts/macbook/overlays/default.nix.";
   };
+  qutebrowser = {
+    strategy = "nixpkgs-pr";
+    description = "Implements FIDO2 support awaiting upstream merging";
+    systems = [ "aarch64-darwin" ];
+    trackingPRs = [
+      {
+        repo = "qutebrowser/qutebrowser";
+        number = 8642;
+      }
+    ];
+  };
 }

--- a/hosts/macbook/overlays/default.nix
+++ b/hosts/macbook/overlays/default.nix
@@ -43,6 +43,16 @@ in
           });
         }
       );
+
+      qutebrowser = _prev.qutebrowser.overrideAttrs (old: {
+        version = "unstable-2026-08-04";
+        src = final.fetchFromGitHub {
+          owner = "coderkun";
+          repo = "qutebrowser";
+          rev = "4c0fc4fdf6721028957cddd3075d8df09e170951";
+          hash = "sha256-BVCbCSh80J7UQm5G2Ub1Ah4yzm58PYiNHR/mbSynDeE=";
+        };
+      });
     })
   ];
 }


### PR DESCRIPTION
Why: native FIDO2/WebAuthn support for qutebrowser isn't merged upstream
yet; its suggested to be complete by the author of a pending PR. I've
tested on Darwin and it works nicely. I may add it to Linux at a later
date if it doesnt get merged.

What:
- override qutebrowser in default.nix to build from coderkun's fork
- add qutebrowser to the audit overlay tracking list, coupled to the
  upstream PR

Notes: Once upstream merges the audit will ideally track vs the relevant
nixpkgs PR and the override will pull from the qutebrowser repo directly.
