### PR TITLE
fix(kitty): set transparent background color for terminal theme

### DIFF
--- a/features/home/kitty/_module.nix
+++ b/features/home/kitty/_module.nix
@@ -10,6 +10,7 @@ _: {
         window_padding_width = 9;
         placement_strategy = "top-left";
         confirm_os_window_close = 3;
+        transparent_background_colors = "#282a36";
       };
       extraConfig = ''
         symbol_map U+e000-U+e00a,U+ea60-U+ebeb,U+e0a0-U+e0c8,U+e0ca,U+e0cc-U+e0d4,U+e200-U+e2a9,U+e300-U+e3e3,U+e5fa-U+e6b1,U+e700-U+e7c5,U+f000-U+f2e0,U+f300-U+f372,U+f400-U+f532,U+f0001-U+f1af0 Symbols Nerd Font Mono


### PR DESCRIPTION
Why: transparent_background_colors was missing, so background
transparency wasnt rendering properly.

What:
- add transparent_background_colors to kitty settings
