### PR TITLE
fix(qutebrowser): move overlay to shared module and add audit metadata

### DIFF
--- a/features/system/core/overlays/_audit.nix
+++ b/features/system/core/overlays/_audit.nix
@@ -1,0 +1,22 @@
+# Temporary overlay audit metadata — read by flake/parts/exports/overlay-audits.nix.
+# Keys must match overlay identifiers in default.nix. No owner/repo#N refs (backlinks).
+# Strategies: nixpkgs-version (attr+threshold), nixpkgs-issue (trackingIssues), nixpkgs-pr (trackingPRs).
+# Required fields for all: strategy, description, systems. Optional: notes (coupled removals etc).
+# Coupled overlays with no independent removal condition: add `# audit-exempt` inside their block in default.nix.
+
+{
+  qutebrowser = {
+    strategy = "nixpkgs-pr";
+    description = "Implements FIDO2 support awaiting upstream merging";
+    systems = [
+      "aarch64-darwin"
+      "x86_64-linux"
+    ];
+    trackingPRs = [
+      {
+        repo = "qutebrowser/qutebrowser";
+        number = 8642;
+      }
+    ];
+  };
+}

--- a/features/system/core/overlays/_module.nix
+++ b/features/system/core/overlays/_module.nix
@@ -3,6 +3,15 @@ _:
 {
   nixpkgs.overlays = [
     (_final: _prev: {
+      qutebrowser = _prev.qutebrowser.overrideAttrs (old: {
+        version = "unstable-2026-08-04";
+        src = _final.fetchFromGitHub {
+          owner = "coderkun";
+          repo = "qutebrowser";
+          rev = "4c0fc4fdf6721028957cddd3075d8df09e170951";
+          hash = "sha256-BVCbCSh80J7UQm5G2Ub1Ah4yzm58PYiNHR/mbSynDeE=";
+        };
+      });
     })
   ];
 }

--- a/flake/parts/exports/overlay-audits.nix
+++ b/flake/parts/exports/overlay-audits.nix
@@ -56,7 +56,7 @@ let
   # This file is imported transitively via systemProfiles and is not reachable
   # through host.overlaysModule. Wire it explicitly here so it gets the same
   # treatment when populated.
-  systemAuditFile = ./../../../features/system/core/overlays/audit.nix;
+  systemAuditFile = ./../../../features/system/core/overlays/_audit.nix;
   systemAudits =
     if builtins.pathExists systemAuditFile then
       let

--- a/hosts/macbook/overlays/default.nix
+++ b/hosts/macbook/overlays/default.nix
@@ -43,16 +43,6 @@ in
           });
         }
       );
-
-      qutebrowser = _prev.qutebrowser.overrideAttrs (old: {
-        version = "unstable-2026-08-04";
-        src = final.fetchFromGitHub {
-          owner = "coderkun";
-          repo = "qutebrowser";
-          rev = "4c0fc4fdf6721028957cddd3075d8df09e170951";
-          hash = "sha256-BVCbCSh80J7UQm5G2Ub1Ah4yzm58PYiNHR/mbSynDeE=";
-        };
-      });
     })
   ];
 }


### PR DESCRIPTION
Why: the qutebrowser FIDO2 overlay lived only in the macbook host's
overlay list, and system-level overlays had no audit tracking to
flag when the upstream PR merges and the pin can be dropped.

What:
- move the qutebrowser overrideAttrs overlay from
  hosts/macbook/overlays/default.nix into the shared
  features/system/core/overlays/_module.nix
- add features/system/core/overlays/_audit.nix documenting the
  qutebrowser overlay's tracking PR (qutebrowser issue 8642)
- repoint flake/parts/exports/overlay-audits.nix at the renamed
  _audit.nix file
