### PR TITLE
chore(deadnix): unused code cleanup pass

### DIFF
--- a/features/home/symlinks/_module.nix
+++ b/features/home/symlinks/_module.nix
@@ -2,7 +2,6 @@
   vars,
   pkgs,
   lib,
-  inputs,
   config,
   ...
 }:

--- a/features/system/containers/pentesting/_module.nix
+++ b/features/system/containers/pentesting/_module.nix
@@ -51,14 +51,14 @@ in
         nixpkgs.config.allowUnfree = true;
         nixpkgs.overlays = [
           (
-            final: prev:
+            _final: prev:
             let
               pinnedPkgs = import inputs.nixpkgs-setuptools-pin { inherit (prev) system; };
             in
             {
               python314Packages = prev.python314Packages // {
                 wfuzz = prev.python314Packages.wfuzz.override {
-                  setuptools = prev.python314Packages.setuptools.overridePythonAttrs (old: {
+                  setuptools = prev.python314Packages.setuptools.overridePythonAttrs (_old: {
                     version = pinnedPkgs.python314Packages.setuptools.version;
                     src = pinnedPkgs.python314Packages.setuptools.src;
                   });

--- a/features/system/core/overlays/_module.nix
+++ b/features/system/core/overlays/_module.nix
@@ -3,7 +3,7 @@ _:
 {
   nixpkgs.overlays = [
     (_final: _prev: {
-      qutebrowser = _prev.qutebrowser.overrideAttrs (old: {
+      qutebrowser = _prev.qutebrowser.overrideAttrs (_old: {
         version = "unstable-2026-08-04";
         src = _final.fetchFromGitHub {
           owner = "coderkun";

--- a/flake/parts/platforms/darwin.nix
+++ b/flake/parts/platforms/darwin.nix
@@ -9,9 +9,6 @@ let
 
   mkDarwinHost =
     host:
-    let
-      packages = repoLib.pkgsFor host.system;
-    in
     inputs.nix-darwin.lib.darwinSystem {
       inherit (host) system;
 

--- a/hosts/gibson/hardware-configuration.nix
+++ b/hosts/gibson/hardware-configuration.nix
@@ -7,7 +7,6 @@
   modulesPath,
   system,
   vars,
-  inputs,
   ...
 }:
 

--- a/hosts/macbook/system.nix
+++ b/hosts/macbook/system.nix
@@ -2,7 +2,6 @@
 # your system. Help is available in the configuration.nix(5) man page, on
 # https://search.nixos.org/options and in the NixOS manual (`nixos-help`).
 {
-  lib,
   pkgs,
   vars,
   ...


### PR DESCRIPTION
Why: Occassionally I get a bit frisky and run a deadnix pass over the
repo to fix any niggles, like unused inputs etc. I just had a frisky
moment.

What:
- Deadnix pass over all repo code conducted
