### PR TITLE
feat(darwin): expose pkgs-stable in darwin specialArgs

### DIFF
--- a/flake/parts/platforms/darwin.nix
+++ b/flake/parts/platforms/darwin.nix
@@ -9,12 +9,16 @@ let
 
   mkDarwinHost =
     host:
+    let
+      packages = repoLib.pkgsFor host.system;
+    in
     inputs.nix-darwin.lib.darwinSystem {
       inherit (host) system;
 
       specialArgs = {
         inherit inputs;
         inherit (host) hostname system vars;
+        inherit (packages) pkgs-stable;
       };
 
       modules =


### PR DESCRIPTION
Why: darwin hosts lacked access to pkgs-stable, unlike nixos hosts,
  which already receive it via pkgsFor for pinning packages against
  the stable channel.

What:
- compute packages via repoLib.pkgsFor host.system in mkDarwinHost
- inherit pkgs-stable into specialArgs alongside inputs and host vars

Notes: This got rm'd on the last commit by deadnix, so I've put it back
in so that both nix/darwin hosts have parity; neither of them leverage
pkgs-stable but its nice to have it exposed should it be required.
