### PR TITLE
fix(zsh): move insert-last-word bindkey to zsh module

### DIFF
--- a/features/home/core/_zsh.nix
+++ b/features/home/core/_zsh.nix
@@ -13,6 +13,8 @@ _: {
         emacsclient -t "$@"
       }
 
+      bindkey -M viins '\e.' insert-last-word
+
       commit-msg() {
         local amend=false
         [[ "$1" == "--amend" || "$1" == "-a" ]] && amend=true

--- a/hosts/gibson/home.nix
+++ b/hosts/gibson/home.nix
@@ -58,10 +58,6 @@
       };
 
       history.path = "${config.xdg.dataHome}/zsh/zsh_history";
-
-      initContent = ''
-        bindkey -M viins '\e.' insert-last-word
-      '';
     };
 
     git.settings.user.signingKey = "7D73BA8CF10F7F67";


### PR DESCRIPTION
Why: the bindkey lived in gibson's home.nix initContent, but it's
a general zsh keybinding, not host-specific config.

What:
- drop initContent block from hosts/gibson/home.nix
- add the bindkey directly in features/home/core/_zsh.nix
