### PR TITLE
fix(macbook): drop tracked qutebrowser fido2 pr overlay entry

### DIFF
--- a/hosts/macbook/overlays/audit.nix
+++ b/hosts/macbook/overlays/audit.nix
@@ -17,15 +17,4 @@
     ];
     notes = "COUPLED REMOVAL: also remove qtwebengine-fix flake input from flake.nix and the qtPinnedPkgs let-binding in hosts/macbook/overlays/default.nix.";
   };
-  qutebrowser = {
-    strategy = "nixpkgs-pr";
-    description = "Implements FIDO2 support awaiting upstream merging";
-    systems = [ "aarch64-darwin" ];
-    trackingPRs = [
-      {
-        repo = "qutebrowser/qutebrowser";
-        number = 8642;
-      }
-    ];
-  };
 }


### PR DESCRIPTION
Why: qutebrowser was still listed for tracking against
upstream PR 8642, but that entry is stale and no longer
relevant to the host specific audit overlay.

What:
- remove the qutebrowser tracked-PR block from
  hosts/macbook/overlays/audit.nix

Notes: Another PR to a githook will be made as this should have been
caught as part of pre-commit really
