### PR TITLE
fix(ci): raise build timeouts, lower retry timeout

### DIFF
--- a/.github/workflows/ci-full-build.yml
+++ b/.github/workflows/ci-full-build.yml
@@ -54,7 +54,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.lockfile_changed == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 240
     permissions:
       contents: read
       id-token: write
@@ -102,7 +102,7 @@ jobs:
         continue-on-error: true
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
         with:
-          timeout_minutes: 90
+          timeout_minutes: 60
           max_attempts: 2
           command: |
             set -euo pipefail
@@ -114,7 +114,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.lockfile_changed == 'true'
     runs-on: macos-latest
-    timeout-minutes: 180 
+    timeout-minutes: 240
     permissions:
       contents: read
       id-token: write
@@ -162,7 +162,7 @@ jobs:
         continue-on-error: true
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
         with:
-          timeout_minutes: 90
+          timeout_minutes: 60
           max_attempts: 2
           command: |
             set -euo pipefail


### PR DESCRIPTION
Why: linux full-build jobs were hitting the 180-minute cap before
completing, while the flake-update retry step's 90-minute timeout was
longer than useful given only 2 attempts are allowed; darwin already
ran at 180 minutes too.

What:
- bump linux and darwin build-job timeouts from 180 to 240 minutes
- cut the nick-fields/retry step timeout from 90 to 60 minutes on
  both platforms - 2hr max.
