### PR TITLE
fix(nix): update home-cache substituter to use HTTPS

### DIFF
--- a/features/system/core/nix/_module.nix
+++ b/features/system/core/nix/_module.nix
@@ -4,7 +4,7 @@ let
   extraSubstituters = [
     "https://nix-community.cachix.org"
     "https://nix-gaming.cachix.org"
-    "http://192.168.1.110:8080/home-cache"
+    "https://attic.home.arpa/home-cache"
   ];
 
   extraTrustedPublicKeys = [


### PR DESCRIPTION
Why: the hardcoded LAN IP for the home cache was replaced by an
  attic instance reachable via mDNS hostname, and the substituter
  now needs https instead of http

What:
- update extraSubstituters entry from the old http IP:port cache
  URL to the new https interal URL
