### PR TITLE
feat(modules): add hugo home-manager module

### DIFF
--- a/features/home/hugo/_module.nix
+++ b/features/home/hugo/_module.nix
@@ -1,0 +1,9 @@
+{
+  pkgs-stable,
+  ...
+}:
+{
+  home.packages = with pkgs-stable; [
+    hugo
+  ];
+}

--- a/features/home/hugo/default.nix
+++ b/features/home/hugo/default.nix
@@ -1,0 +1,3 @@
+_: {
+  flake.modules.homeManager.hugo = ./_module.nix;
+}

--- a/flake/parts/platforms/darwin.nix
+++ b/flake/parts/platforms/darwin.nix
@@ -34,6 +34,9 @@ let
           hmExtra = {
             backupFileExtension = "before-nix";
           };
+          extraSpecialArgs = {
+            inherit (packages) pkgs-stable;
+          };
         };
     };
 

--- a/profiles/home/darwin.nix
+++ b/profiles/home/darwin.nix
@@ -7,8 +7,9 @@
     inputs.self.modules.homeManager.doomemacs
     inputs.self.modules.homeManager.ghostty
     inputs.self.modules.homeManager.github-cli
-    inputs.self.modules.homeManager.qutebrowser
+    inputs.self.modules.homeManager.hugo
     inputs.self.modules.homeManager.nix-settings
+    inputs.self.modules.homeManager.qutebrowser
     inputs.self.modules.homeManager.sops-nix
     inputs.self.modules.homeManager.stylix
     inputs.self.modules.homeManager.symlinks


### PR DESCRIPTION
Why: Im wanting to revive my old gitub pages site so im setting up hugo
to do just that.

What:
- add hugo home-manager feature module (features/home/hugo)
- pass pkgs-stable through extraSpecialArgs for darwin home-manager
- wire hugo module into the darwin home profile

Notes: profiles/home/darwin.nix module list re-sorted
alphabetically as part of insertion. This will also be propagated to
gibson at some point.
