### PR TITLE
fix(gibson): disable nvidia gsync and vrr env vars

### DIFF
--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -156,8 +156,8 @@
       WLR_NO_HARDWARE_CURSORS = "1";
       __GLX_VENDOR_LIBRARY_NAME = "nvidia";
       __GL_MaxFramesAllowed = "1";
-      __GL_GSYNC_ALLOWED = "1";
-      __GL_VRR_ALLOWED = "1";
+      __GL_GSYNC_ALLOWED = "0";
+      __GL_VRR_ALLOWED = "0";
     };
 
     pathsToLink = [


### PR DESCRIPTION
Why: gsync/vrr env vars were causing instability (flicker/stutter) with
  certain games on gibson's nvidia setup

What:
- set __GL_GSYNC_ALLOWED to "0"
- set __GL_VRR_ALLOWED to "0"

Notes: I noted a marked improvement on performance for some games, e.g.
  Alake Wake II, as a result of this change. The compositor is still
  configured to handle VRR for fullscreen games, the above vars
  apparently cause some kind of performance degrading conflict.
