### PR TITLE
fix(ci): correct gitleaks invocation for v8 subcommand syntax

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 echo "Running gitleaks (native) …"
-nix run nixpkgs#gitleaks -- protect --staged --redact --config .github/gitleaks.toml 
+nix run nixpkgs#gitleaks -- git --pre-commit --staged --redact --config .github/gitleaks.toml
 
 echo "Running flake shape check …"
 nix flake show --no-write-lock-file >/dev/null

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Run gitleaks (native)
         run: |
           set -euo pipefail
-          nix run nixpkgs#gitleaks -- detect --source . --redact --config .github/gitleaks.toml 
+          nix run nixpkgs#gitleaks -- git --redact --config .github/gitleaks.toml
 
   flake-secrets-check:
     name: full flake check (with secrets)


### PR DESCRIPTION
Why: gitleaks commands in githooks/ci used a subcommand
  syntax (`protect`, `detect --source`) that no longer matches
  recommended options, and both will be deprecated at some point

What:
- update pre-push hook to use `git --pre-commit`
- update CI workflow to use `git` for full-history scan
