### PR TITLE
fix(ci): gate full-build jobs on attic cache reachability

### DIFF
--- a/.github/workflows/ci-full-build.yml
+++ b/.github/workflows/ci-full-build.yml
@@ -49,10 +49,26 @@ jobs:
             echo "lockfile_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-  eval-check:
-    name: full build check (linux)
+  check-cache:
+    name: verify attic cache is reachable
+    runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.lockfile_changed == 'true'
+    steps:
+      - name: Verify attic cache is reachable
+        run: |
+          curl --fail --silent --show-error --max-time 30 \
+            http://attic.taileda465.ts.net:8080/home-cache/nix-cache-info
+
+  eval-check:
+    name: full build check (linux)
+    needs:
+      - changes
+      - check-cache
+    if: |
+      needs.changes.result == 'success' &&
+      needs.check-cache.result == 'success' &&
+      needs.changes.outputs.lockfile_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 240
     permissions:
@@ -107,12 +123,17 @@ jobs:
           command: |
             set -euo pipefail
             nix run nixpkgs#attic-client -- login home http://attic.taileda465.ts.net:8080 "${{ secrets.TS_CI_ATTIC_PUSH_TOKEN }}"
-            nix run nixpkgs#attic-client -- push home:home-cache --ignore-upstream-cache-filter -j 1 ./result
+            nix run nixpkgs#attic-client -- push home:home-cache --ignore-upstream-cache-filter -j 2 ./result
 
   darwin-eval-check:
     name: full build check (darwin)
-    needs: changes
-    if: needs.changes.outputs.lockfile_changed == 'true'
+    needs:
+      - changes
+      - check-cache
+    if: |
+      needs.changes.result == 'success' &&
+      needs.check-cache.result == 'success' &&
+      needs.changes.outputs.lockfile_changed == 'true'
     runs-on: macos-latest
     timeout-minutes: 240
     permissions:
@@ -167,4 +188,4 @@ jobs:
           command: |
             set -euo pipefail
             nix run nixpkgs#attic-client -- login home http://attic.taileda465.ts.net:8080 "${{ secrets.TS_CI_ATTIC_PUSH_TOKEN }}"
-            nix run nixpkgs#attic-client -- push home:home-cache --ignore-upstream-cache-filter -j 1 ./result
+            nix run nixpkgs#attic-client -- push home:home-cache --ignore-upstream-cache-filter -j 2 ./result


### PR DESCRIPTION
Why: full-build jobs would proceed even when the attic cache was
unreachable, wasting CI minutes on evaluations that later failed to
push results.

What:
- add check-cache job that curls the attic nix-cache-info endpoint
  before eval-check/darwin-eval-check run
- only run check-cache when the lockfile changed, and require it to
  explicitly succeed (along with changes) before eval-check and
  darwin-eval-check run
- make eval-check and darwin-eval-check depend on check-cache in
  addition to changes
- bump attic-client push concurrency from -j 1 to -j 2