### PR TITLE
fix(nix): use hostPlatform.isLinux/isDarwin over deprecated aliases

### DIFF
--- a/features/home/syncthing/_linux-bootstrap.nix
+++ b/features/home/syncthing/_linux-bootstrap.nix
@@ -25,7 +25,7 @@ let
   syncthingConfigFile = "${config.home.homeDirectory}/.local/state/syncthing/config.xml";
 in
 {
-  config = mkIf (pkgs.stdenv.isLinux && bootstrapFolders != { }) {
+  config = mkIf (pkgs.stdenv.hostPlatform.isLinux && bootstrapFolders != { }) {
     systemd.user.services.syncthing-bootstrap = {
       Unit = {
         Description = "Safe first-sync bootstrap for Syncthing";

--- a/features/home/syncthing/_module.nix
+++ b/features/home/syncthing/_module.nix
@@ -195,7 +195,10 @@ in
     }
 
     (mkIf
-      (!pkgs.stdenv.isLinux && builtins.any (f: f.bootstrap.enable) (builtins.attrValues enabledFolders))
+      (
+        !pkgs.stdenv.hostPlatform.isLinux
+        && builtins.any (f: f.bootstrap.enable) (builtins.attrValues enabledFolders)
+      )
       {
         assertions = [
           {

--- a/features/system/core/nix/_module.nix
+++ b/features/system/core/nix/_module.nix
@@ -14,7 +14,7 @@ let
   ];
 in
 {
-  nix.settings = lib.mkIf pkgs.stdenv.isLinux {
+  nix.settings = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     substituters = [
       "https://cache.nixos.org"
     ]
@@ -26,7 +26,7 @@ in
     ++ extraTrustedPublicKeys;
   };
 
-  environment.etc."nix/nix.custom.conf" = lib.mkIf pkgs.stdenv.isDarwin {
+  environment.etc."nix/nix.custom.conf" = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     text = ''
       extra-substituters = ${lib.concatStringsSep " " extraSubstituters}
       extra-trusted-public-keys = ${lib.concatStringsSep " " extraTrustedPublicKeys}

--- a/flake/parts/outputs/packages.nix
+++ b/flake/parts/outputs/packages.nix
@@ -2,7 +2,7 @@
   perSystem =
     { pkgs, lib, ... }:
     {
-      packages = lib.optionalAttrs pkgs.stdenv.isLinux {
+      packages = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
         dim-screen = pkgs.callPackage ./../../../pkgs/dim-screen { };
         sddm-astronaut-theme = pkgs.callPackage ./../../../pkgs/sddm-themes { };
         game-cleanup = pkgs.callPackage ./../../../pkgs/game-cleanup { };


### PR DESCRIPTION
Why: pkgs.stdenv.isLinux/isDarwin are deprecated aliases in newer
nixpkgs so rebuilds emit warnings. These have been cleaned up.

What:
- swap stdenv.isLinux/isDarwin for stdenv.hostPlatform.isLinux/isDarwin
  in syncthing bootstrap/module, core nix module, and packages output

Notes: no behavioural change, purely an API migration to the
supported nixpkgs accessor
