### PR TITLE
fix(gibson): use hostPlatform.system for overlay pkgs import

### DIFF
--- a/features/system/containers/pentesting/_module.nix
+++ b/features/system/containers/pentesting/_module.nix
@@ -53,7 +53,7 @@ in
           (
             _final: prev:
             let
-              pinnedPkgs = import inputs.nixpkgs-setuptools-pin { inherit (prev) system; };
+              pinnedPkgs = import inputs.nixpkgs-setuptools-pin { inherit (prev.stdenv.hostPlatform) system; };
             in
             {
               python314Packages = prev.python314Packages // {

--- a/hosts/gibson/overlays/overlay-entries.nix
+++ b/hosts/gibson/overlays/overlay-entries.nix
@@ -53,7 +53,7 @@
                 hash = "sha256-IpX7tmVJi9seHg5M4Wuexy78bQDlbntVk1HcT9kFts4=";
               })
               {
-                inherit (prev) system;
+                inherit (prev.stdenv.hostPlatform) system;
                 config.allowUnfree = true;
               };
         in

--- a/profiles/home/desktop.nix
+++ b/profiles/home/desktop.nix
@@ -10,6 +10,7 @@
     inputs.self.modules.homeManager.gaming
     inputs.self.modules.homeManager.github-cli
     inputs.self.modules.homeManager.hypr
+    inputs.self.modules.homeManager.hugo
     inputs.self.modules.homeManager.kitty
     inputs.self.modules.homeManager.mako
     inputs.self.modules.homeManager.media


### PR DESCRIPTION
- **feat(home): enable hugo module in desktop profile**
- **fix(gibson): use hostPlatform.system for overlay pkgs import**
