### PR TITLE
fix(doomemacs): wait for doom-modules sync before emacs.service starts

### DIFF
--- a/features/home/doomemacs/_module.nix
+++ b/features/home/doomemacs/_module.nix
@@ -110,6 +110,23 @@ mkMerge [
       };
       startWithUserSession = true;
     };
+
+    # installDoomEmacs (above) runs via the system-level
+    # home-manager-${username}.service, which has no ordering relative to this
+    # user-level emacs.service (WantedBy=default.target).  On a cold boot they
+    # race; this will guard against starting before the doomemacs-modules rsync
+    # has completed.
+    systemd.user.services.emacs.Service.ExecStartPre = [
+      "${pkgs.writeShellScript "wait-for-doom-modules" ''
+        marker="${config.xdg.configHome}/emacs/sources/doom+/modules/ui/doom/config.el"
+        for _ in $(seq 1 30); do
+          [ -e "$marker" ] && exit 0
+          sleep 1
+        done
+        echo "wait-for-doom-modules: gave up after 30s waiting for $marker" >&2
+        exit 0
+      ''}"
+    ];
   })
 
   (mkIf pkgs.stdenv.hostPlatform.isDarwin {


### PR DESCRIPTION
Why: installDoomEmacs runs via the system-level
home-manager-${username}.service, which has no ordering relative to
the user-level emacs.service (WantedBy=default.target). On a cold
boot these can race, starting emacs before the doomemacs-modules
rsync has completed and this causes breakage util the emacs service is
manually restarted.

What:
- add ExecStartPre to systemd.user.services.emacs that polls for the
  doom+ modules marker file for up to 30s before starting
