### PR TITLE
feat(home): enable hugo module in desktop profile

### DIFF
--- a/profiles/home/desktop.nix
+++ b/profiles/home/desktop.nix
@@ -10,6 +10,7 @@
     inputs.self.modules.homeManager.gaming
     inputs.self.modules.homeManager.github-cli
     inputs.self.modules.homeManager.hypr
+    inputs.self.modules.homeManager.hugo
     inputs.self.modules.homeManager.kitty
     inputs.self.modules.homeManager.mako
     inputs.self.modules.homeManager.media


### PR DESCRIPTION
Why: desktop hosts need hugo available for building/serving static
sites but the home-manager module was never wired into the desktop
profile.

What:
- import inputs.self.modules.homeManager.hugo in profiles/home/desktop.nix
