### PR TITLE
fix(gibson): use hostPlatform.system for overlay pkgs import

### DIFF
--- a/features/system/containers/pentesting/_module.nix
+++ b/features/system/containers/pentesting/_module.nix
@@ -53,7 +53,7 @@ in
           (
             _final: prev:
             let
-              pinnedPkgs = import inputs.nixpkgs-setuptools-pin { inherit (prev) system; };
+              pinnedPkgs = import inputs.nixpkgs-setuptools-pin { inherit (prev.stdenv.hostPlatform) system; };
             in
             {
               python314Packages = prev.python314Packages // {

--- a/hosts/gibson/overlays/overlay-entries.nix
+++ b/hosts/gibson/overlays/overlay-entries.nix
@@ -53,7 +53,7 @@
                 hash = "sha256-IpX7tmVJi9seHg5M4Wuexy78bQDlbntVk1HcT9kFts4=";
               })
               {
-                inherit (prev) system;
+                inherit (prev.stdenv.hostPlatform) system;
                 config.allowUnfree = true;
               };
         in


### PR DESCRIPTION
Why: continues the isLinux/isDarwin cleanup (#314) —  `inherit (prev)
system` flags warnings as the `prev.system` alias is now deprecated, so
overlays must read `prev.stdenv.hostPlatform.system` instead.

What:
- pentesting container overlay: pin nixpkgs-setuptools-pin to
  prev.stdenv.hostPlatform.system
- gibson overlay-entries: import pinned nixpkgs using
  prev.stdenv.hostPlatform.system
