### PR TITLE
fix(attic-client): switch to interal domain on https

### DIFF
--- a/features/system/attic-client/_darwin.nix
+++ b/features/system/attic-client/_darwin.nix
@@ -8,8 +8,8 @@
       export HOME=/var/lib/attic-watch-store
       mkdir -p "$HOME"
       ${pkgs.attic-client}/bin/attic login home \
-        http://192.168.1.110:8080 "$(cat ${config.sops.secrets."services/attic/token".path})"
-      exec ${pkgs.attic-client}/bin/attic watch-store --ignore-upstream-cache-filter -j 1 home:home-cache
+        https://attic.home.arpa "$(cat ${config.sops.secrets."services/attic/token".path})"
+      exec ${pkgs.attic-client}/bin/attic watch-store --ignore-upstream-cache-filter -j 2 home:home-cache
     '';
     serviceConfig = {
       KeepAlive = true;

--- a/features/system/attic-client/_nixos.nix
+++ b/features/system/attic-client/_nixos.nix
@@ -28,8 +28,8 @@
       ExecStart = pkgs.writeShellScript "attic-watch-store-start" ''
         set -euo pipefail
         ${pkgs.attic-client}/bin/attic login home \
-          http://192.168.1.110:8080 "$(cat ${config.sops.secrets."services/attic/token".path})"
-        exec ${pkgs.attic-client}/bin/attic watch-store --ignore-upstream-cache-filter -j 1 home:home-cache
+          https://attic.home.arpa "$(cat ${config.sops.secrets."services/attic/token".path})"
+        exec ${pkgs.attic-client}/bin/attic watch-store --ignore-upstream-cache-filter -j 2 home:home-cache
       '';
       Restart = "on-failure";
       RestartSec = 10;


### PR DESCRIPTION
Why: the attic server now sits behind a reverse proxy on so clients
pointed at the raw http://192.168.1.110:8080 endpoint could no longer
authenticate.

What:
- point darwin and nixos attic-client watch-store units at
  https://attic.home.arpa
- bump nixos watch-store concurrency from -j 1 to -j 2
