### PR TITLE
feat(pkgs): support darwin in nix-build-system script

### DIFF
--- a/features/home/nix-settings/_module.nix
+++ b/features/home/nix-settings/_module.nix
@@ -5,8 +5,7 @@
   ...
 }:
 let
-  inherit (lib) optional;
-  inherit (pkgs.stdenv.hostPlatform) isLinux system;
+  inherit (pkgs.stdenv.hostPlatform) system;
 in
 {
   nix = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
@@ -17,11 +16,12 @@ in
     nixPath = [ "nixpkgs=${inputs.nixpkgs}" ];
   };
 
-  home.packages =
-    optional isLinux inputs.self.packages.${system}.nix-build-system
-    ++ (with pkgs; [
-      nixfmt
-      nixd
-      statix
-    ]);
+  home.packages = [
+    inputs.self.packages.${system}.nix-build-system
+  ]
+  ++ (with pkgs; [
+    nixfmt
+    nixd
+    statix
+  ]);
 }

--- a/flake/parts/outputs/packages.nix
+++ b/flake/parts/outputs/packages.nix
@@ -2,13 +2,17 @@
   perSystem =
     { pkgs, lib, ... }:
     {
-      packages = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
-        dim-screen = pkgs.callPackage ./../../../pkgs/dim-screen { };
-        sddm-astronaut-theme = pkgs.callPackage ./../../../pkgs/sddm-themes { };
-        game-cleanup = pkgs.callPackage ./../../../pkgs/game-cleanup { };
-        nix-build-system = pkgs.callPackage ./../../../pkgs/nix-build-system { };
-        xivlauncher-rb = pkgs.callPackage ./../../../pkgs/nixos-xivlauncher-rb { };
-      };
+      packages =
+        lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+          dim-screen = pkgs.callPackage ./../../../pkgs/dim-screen { };
+          sddm-astronaut-theme = pkgs.callPackage ./../../../pkgs/sddm-themes { };
+          game-cleanup = pkgs.callPackage ./../../../pkgs/game-cleanup { };
+          nix-build-system = pkgs.callPackage ./../../../pkgs/nix-build-system { };
+          xivlauncher-rb = pkgs.callPackage ./../../../pkgs/nixos-xivlauncher-rb { };
+        }
+        // {
+          nix-build-system = pkgs.callPackage ./../../../pkgs/nix-build-system { };
+        };
     };
 
   flake.overlays.default = final: _prev: {

--- a/pkgs/nix-build-system/default.nix
+++ b/pkgs/nix-build-system/default.nix
@@ -1,4 +1,22 @@
 { pkgs }:
+let
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+
+  rebuild =
+    if isDarwin then
+      ''darwin-rebuild build --flake "$CONFIG" --option eval-cache false --show-trace''
+    else
+      ''nixos-rebuild --flake "$CONFIG" build --option eval-cache false --show-trace'';
+
+  # No exact darwin equivalent of systemd-inhibit's --mode=block/--why semantics;
+  # caffeinate -is is the closest analogue (idle + AC-power system sleep, released
+  # automatically when the wrapped command exits, exit code passed through).
+  inhibit =
+    if isDarwin then
+      "caffeinate -is"
+    else
+      ''systemd-inhibit --no-pager --no-legend --mode=block --who="''${USER:-$(id -un)}" --why='NixOS System Building' '';
+in
 pkgs.writeShellApplication {
   name = "nix-build-system";
   runtimeInputs = with pkgs; [
@@ -12,21 +30,17 @@ pkgs.writeShellApplication {
     cd "$CONFIG"
     echo "Beginning build. This may take some time."
     echo ""
-    systemd-inhibit --no-pager --no-legend --mode=block --who="''${USER:-$(id -un)}" --why='NixOS System Building' nixos-rebuild --flake "$CONFIG" build --option eval-cache false --show-trace
-
+    ${inhibit} ${rebuild}
     echo ""
     echo "Build complete. Providing result:"
     echo ""
     rm -rf ~/changes_*
     nvd diff /run/current-system "$CONFIG"/result > "$OUTFILE"
-
     #Cleanup
     awk -i inplace '{$0=gensub(/\s*\S+/,"",2)}1' "$OUTFILE"
     sed -i -e '1,2d' -e 's/Version/Changed\/Updated:/g' -e 's/Added/\nAdded:/g' -e 's/Removed/\nRemoved:/g' -e '$d' "$OUTFILE"
     rm "$CONFIG"/result
-
     cat "$OUTFILE"
-
-    echo "Result has been stored in $HOME/$OUTFILE. Finished"
+    echo "Result has been stored in $OUTFILE. Finished"
   '';
 }


### PR DESCRIPTION
Why: nix-build-system only worked on NixOS (via nixos-rebuild and
systemd-inhibit) but is now also usable on nix-darwin machines.

What:
- implement logic to use darwin-rebuild and caffeinate -is instead of
  nixos-rebuild and systemd-inhibit
- expose nix-build-system package unconditionally instead of being gated
  on Linux systems
