### PR TITLE
fix(waybar): mojibake in cpu/memory icon glyphs

### DIFF
--- a/features/home/waybar/_module.nix
+++ b/features/home/waybar/_module.nix
@@ -64,13 +64,13 @@ lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
         };
 
         cpu = {
-          format = " {usage}%";
+          format = " {usage}%";
           interval = 10;
           tooltip = false;
         };
 
         memory = {
-          format = " {used:0.1f}G";
+          format = " {used:0.1f}G";
         };
 
         disk = {


### PR DESCRIPTION
Why: the icon glyphs in the cpu and memory module formats were
  showing as garbled mojibake instead of the intended icons.

What:
- replace corrupted glyph bytes in cpu format with the correct icon
- replace corrupted glyph bytes in memory format with the correct icon
