### PR TITLE
feat(hosts): add attic binary cache host and server module

### DIFF
--- a/bootstrap/deploy-attic.sh
+++ b/bootstrap/deploy-attic.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Deploys attic from gibson (or any host with nix-secrets access). Never run
+# this — or any flake evaluation against .#attic — locally on attic itself;
+# see the comment at the top of hosts/attic/system.nix for why.
+#
+# No sudo anywhere below, deliberately: --target-host activation happens as
+# root on attic over SSH, not locally — local sudo isn't just unnecessary
+# here, it actively breaks things (env vars/SSH_AUTH_SOCK don't reliably
+# survive the hop, and nixos-rebuild is separately aliased to sudo-wrap
+# itself on this box — see hosts/gibson/home.nix).
+#
+# Pushes the atticd env secret out of nix-secrets and over SSH as a plain
+# file, root:root 0600. attic gets no age key and no sops-nix module: this
+# is the one deliberate exception to "no secrets on this host" — a
+# transient plaintext file delivered over an already-trusted channel,
+# functionally the same manual step you were doing before, just sourced
+# from version control instead of memory.
+set -euo pipefail
+TARGET="root@192.168.1.110"
+# Same resolution flake/lib/mk-vars.nix already does for every other host
+# (secretsPath = toString inputs.nix-secrets) — derived from the flake's own
+# locked input instead of a separately-maintained env var, so it can't drift
+# from what flake.lock actually pins.
+SECRETS_PATH="$(nix eval --impure --raw --expr '(builtins.getFlake (toString ./.)).inputs.nix-secrets.outPath')"
+SECRETS_FILE="$SECRETS_PATH/secrets/secrets.yaml"
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: working tree is dirty — commit first. A switch built from an" >&2
+  echo "       uncommitted tree can't be reproduced from git history alone." >&2
+  exit 1
+fi
+# DEPLOY_KEY is passphrase-less on disk by design (root's authorized_keys on
+# attic is scoped to just this key; no human is present at automation time
+# to type a passphrase). -i reads it directly and never touches any agent —
+# deliberately: this box's SSH agent is gpg-agent, which imports anything
+# handed to it via ssh-add into its own key store and demands a *separate*
+# storage passphrase for it, which is exactly the friction a bare -i avoids.
+DEPLOY_KEY="${DEPLOY_KEY:-$HOME/.ssh/deploy}"
+if [ -z "${NIX_SSHOPTS:-}" ]; then
+  export NIX_SSHOPTS="-i $DEPLOY_KEY"
+fi
+# shellcheck disable=SC2206 # intentional word-split of a flag string into an array
+SSH_OPTS=($NIX_SSHOPTS)
+echo "==> pushing atticd env to ${TARGET}"
+sops --decrypt --extract '["services"]["attic"]["server-token"]' "$SECRETS_FILE" \
+  | ssh "${SSH_OPTS[@]}" "$TARGET" 'install -m 0600 /dev/stdin /var/lib/attic/env'
+echo "==> building + switching .#attic on ${TARGET}"
+nixos-rebuild switch --flake ".#attic" --target-host "$TARGET"

--- a/features/attic-server/_module.nix
+++ b/features/attic-server/_module.nix
@@ -1,0 +1,65 @@
+{ pkgs, ... }:
+{
+  # atticd's HS256 signing secret lives in /var/lib/attic/env, a plain
+  # root:root 0600 file outside the Nix store — delivered by
+  # bootstrap/deploy-attic.sh from nix-secrets (services.attic.server-token),
+  # not by sops-nix. This host intentionally has no age key, so it never
+  # decrypts anything itself; systemd reads EnvironmentFile as root before
+  # dropping to atticd's user, so the file's ownership doesn't need to
+  # match the service user.
+  services.atticd = {
+    enable = true;
+    user = "atticd";
+    group = "atticd";
+    environmentFile = "/var/lib/attic/env";
+    settings = {
+      listen = "[::]:8080";
+      allowed-hosts = [
+        "attic.home.arpa"
+        "attic.taileda465.ts.net"
+        "attic.taileda465.ts.net:8080"
+      ];
+      database.url = "sqlite:///var/lib/atticd/server.db?mode=rwc";
+      storage = {
+        type = "local";
+        path = "/mnt/attic-cache";
+      };
+      chunking = {
+        nar-size-threshold = 65536;
+        min-size = 16384;
+        avg-size = 65536;
+        max-size = 262144;
+      };
+      garbage-collection = {
+        interval = "12 hours";
+        default-retention-period = "2 weeks";
+      };
+    };
+  };
+
+  # uid/gid pinned to match ownership on the existing NFS-backed
+  # /mnt/attic-cache bind mount — do not renumber without also chowning
+  # the storage path.
+  users.users.atticd = {
+    isSystemUser = true;
+    group = "atticd";
+    uid = 990;
+  };
+  users.groups.atticd.gid = 990;
+
+  # Explicit LAN allowlist for the plain-HTTP :8080 API — everything else
+  # on the LAN is denied; Tailscale clients bypass this entirely via
+  # networking.firewall.trustedInterfaces (see features/tailscale).
+  networking.firewall.extraCommands = ''
+    iptables -A nixos-fw -p tcp -s 192.168.1.5 --dport 8080 -j ACCEPT
+    iptables -A nixos-fw -p tcp -s 192.168.1.7 --dport 8080 -j ACCEPT
+  '';
+  networking.firewall.extraStopCommands = ''
+    iptables -D nixos-fw -p tcp -s 192.168.1.5 --dport 8080 -j ACCEPT || true
+    iptables -D nixos-fw -p tcp -s 192.168.1.7 --dport 8080 -j ACCEPT || true
+  '';
+
+  environment.systemPackages = [
+    pkgs.attic-client
+  ];
+}

--- a/features/attic-server/default.nix
+++ b/features/attic-server/default.nix
@@ -1,0 +1,3 @@
+_: {
+  flake.modules.nixos.attic-server = ./_module.nix;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -507,11 +507,11 @@
     "nix-secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1783181149,
-        "narHash": "sha256-rRWY3Nzo+UyDBfV4yNeQjpw9x7qo3MK7QcsI+rD9F/8=",
+        "lastModified": 1787500419,
+        "narHash": "sha256-YywTyqzXd5o/lG4Cb81N/r2Udr+cTfnWPM1Pe/fOtHI=",
         "ref": "main",
-        "rev": "341cbcafdbd055c0e4663107c8a788d9e81456bd",
-        "revCount": 24,
+        "rev": "d3354c0166a069f7ff601344d63db3f9f96d8266",
+        "revCount": 25,
         "type": "git",
         "url": "ssh://git@github.com/5ysk3y/nix-secrets.git"
       },

--- a/flake/hosts/attic.nix
+++ b/flake/hosts/attic.nix
@@ -1,0 +1,38 @@
+{
+  inputs,
+  mkVars,
+  username,
+}:
+let
+  hostname = "attic";
+  system = "x86_64-linux";
+  path = ./../../hosts/attic;
+in
+rec {
+  # No home-manager, no sops-nix, no YubiKey — see registry.nix for what
+  # this kind skips.
+  kind = "nixos-minimal";
+  inherit hostname system path;
+
+  systemModule = path + /system.nix;
+  overlaysModule = path + /overlays;
+
+  systemProfiles = [
+    ./../../profiles/system/nixos.nix
+    ./../../profiles/system/server.nix
+  ];
+
+  modules = [
+    systemModule
+    overlaysModule
+  ];
+
+  vars = mkVars {
+    inherit
+      inputs
+      username
+      hostname
+      system
+      ;
+  };
+}

--- a/flake/hosts/default.nix
+++ b/flake/hosts/default.nix
@@ -19,4 +19,12 @@
       username
       ;
   };
+
+  attic = import ./attic.nix {
+    inherit
+      inputs
+      mkVars
+      username
+      ;
+  };
 }

--- a/flake/parts/hosts/registry.nix
+++ b/flake/parts/hosts/registry.nix
@@ -17,6 +17,7 @@ in
             kind = lib.mkOption {
               type = lib.types.enum [
                 "nixos"
+                "nixos-minimal" # No home-manager/secrets/yubikey config
                 "darwin"
               ];
             };
@@ -38,7 +39,9 @@ in
             };
 
             homeModule = lib.mkOption {
-              type = lib.types.path;
+              type = lib.types.nullOr lib.types.path;
+              default = null;
+              description = "Not required for kind = \"nixos-minimal\" — those hosts get no Home Manager module at all.";
             };
 
             overlaysModule = lib.mkOption {
@@ -57,7 +60,7 @@ in
 
             homeProfiles = lib.mkOption {
               type = lib.types.listOf lib.types.path;
-              readOnly = true;
+              default = [ ];
             };
 
             vars = lib.mkOption {
@@ -82,7 +85,14 @@ in
         };
       };
 
-      filterHosts = kind: hosts: lib.filterAttrs (_: v: v.kind == kind) hosts;
+      # `kinds` may be a single kind string or a list of kinds (e.g. both
+      # "nixos" and "nixos-minimal" build through the same nixosSystem path).
+      filterHosts =
+        kinds: hosts:
+        let
+          kindList = if builtins.isList kinds then kinds else [ kinds ];
+        in
+        lib.filterAttrs (_: v: builtins.elem v.kind kindList) hosts;
       mapHosts = f: hosts: lib.mapAttrs (_: f) hosts;
 
       mkHomeManagerModule =

--- a/flake/parts/platforms/nixos.nix
+++ b/flake/parts/platforms/nixos.nix
@@ -1,5 +1,6 @@
 {
   config,
+  lib,
   inputs,
   repoLib,
   ...
@@ -11,6 +12,10 @@ let
     host:
     let
       packages = repoLib.pkgsFor host.system;
+      # kind = "nixos-minimal" hosts get neither sops-nix nor Home Manager —
+      # see flake/parts/hosts/registry.nix for why this is a distinct kind
+      # rather than a per-host toggle.
+      hasSecretsAndHome = host.kind == "nixos";
     in
     inputs.nixpkgs.lib.nixosSystem {
       inherit (host) system;
@@ -25,22 +30,24 @@ let
         host.systemProfiles
         ++ host.modules
         ++ [ { nixpkgs.config.allowUnfree = true; } ]
-        ++ [
+        ++ lib.optionals hasSecretsAndHome [
           inputs.sops-nix.nixosModules.sops
         ]
-        ++ repoLib.mkHomeManagerModule {
-          platformModule = inputs.home-manager.nixosModules.home-manager;
-          inherit host;
-          hmExtra = {
-            backupFileExtension = "before-nix";
-          };
-          extraSpecialArgs = {
-            inherit (packages) pkgs-stable;
-          };
-        };
+        ++ lib.optionals hasSecretsAndHome (
+          repoLib.mkHomeManagerModule {
+            platformModule = inputs.home-manager.nixosModules.home-manager;
+            inherit host;
+            hmExtra = {
+              backupFileExtension = "before-nix";
+            };
+            extraSpecialArgs = {
+              inherit (packages) pkgs-stable;
+            };
+          }
+        );
     };
 
-  nixosHosts = repoLib.filterHosts "nixos" hosts;
+  nixosHosts = repoLib.filterHosts [ "nixos" "nixos-minimal" ] hosts;
 in
 {
   flake.nixosConfigurations = repoLib.mapHosts mkNixosHost nixosHosts;

--- a/hosts/attic/overlays/default.nix
+++ b/hosts/attic/overlays/default.nix
@@ -1,0 +1,4 @@
+# No host-specific overlays needed for attic. This file exists only
+# because registry.nix requires every host to declare an overlaysModule
+# (imported directly as a module path by flake/hosts/attic.nix).
+_: { }

--- a/hosts/attic/system.nix
+++ b/hosts/attic/system.nix
@@ -1,0 +1,88 @@
+# Attic binary cache — Proxmox LXC, deployed remotely over the LAN
+# from any machine which already has nix-secrets access:
+#   nixos-rebuild switch --flake .#attic --target-host root@192.168.1.110
+# (root SSH is key-only below, so --use-remote-sudo isn't needed).
+#
+# Never `switch` locally on this host — see the repo README/CI notes on why
+# nix-secrets makes local flake evaluation here a non-starter regardless of
+# what this host's own modules reference.
+#
+# Tailscale on this host is unrelated to the above — it exists solely so
+# GitHub Actions runners can reach the :8080 cache API for CI build/push,
+# same as the CI-facing allowed-hosts entries in features/attic-server.
+# It plays no part in LAN admin/deploy access.
+{
+  pkgs,
+  hostname,
+  modulesPath,
+  ...
+}:
+{
+  imports = [
+    "${modulesPath}/virtualisation/proxmox-lxc.nix"
+  ];
+
+  networking = {
+    hostName = hostname;
+    useDHCP = false;
+    interfaces.eth0.ipv4.addresses = [
+      {
+        address = "192.168.1.110";
+        prefixLength = 24;
+      }
+    ];
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "eth0";
+    };
+    nameservers = [
+      "192.168.1.1"
+    ];
+  };
+
+  services.resolved.enable = true;
+
+  proxmoxLXC = {
+    manageNetwork = false;
+    privileged = false;
+  };
+
+  services.openssh = {
+    enable = true;
+    openFirewall = false;
+    settings = {
+      PasswordAuthentication = false;
+      KbdInteractiveAuthentication = false;
+      PermitRootLogin = "prohibit-password";
+    };
+  };
+
+  # LAN allowlist for SSH — same extraCommands pattern as atticd's :8080
+  # allowlist below, scoped to just gibson (192.168.1.100), the only host
+  # that ever deploys to attic.
+  networking.firewall.extraCommands = ''
+    iptables -A nixos-fw -p tcp -s 192.168.1.100 --dport 22 -j ACCEPT
+    iptables -A nixos-fw -p tcp -s 192.168.1.113 --dport 22 -j ACCEPT
+  '';
+  networking.firewall.extraStopCommands = ''
+    iptables -D nixos-fw -p tcp -s 192.168.1.100 --dport 22 -j ACCEPT || true
+    iptables -D nixos-fw -p tcp -s 192.168.1.113 --dport 22 -j ACCEPT || true
+  '';
+
+  # TODO: replace with gibson's actual SSH public key (e.g. from
+  # /etc/ssh/ssh_host_ed25519_key.pub or a dedicated deploy keypair) —
+  # required for `nixos-rebuild --target-host` to reach this box.
+  users.users.root.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHDYsCglDjOEYHw6fpBL7KorictTA8314+K5VA6QaOko"
+  ];
+
+  environment.systemPackages = with pkgs; [
+    vim
+    git
+    curl
+    wget
+    openssl
+  ];
+
+  system.stateVersion = "25.05"; # inherited from the original LXC install — do not bump to match other hosts
+}

--- a/hosts/gibson/system.nix
+++ b/hosts/gibson/system.nix
@@ -13,6 +13,10 @@
     inputs.self.modules.nixos.nvidia
   ];
 
+  security.sudo.extraConfig = ''
+    Defaults env_keep+=NIX_SSHOPTS
+  '';
+
   networking = {
     useDHCP = false;
     dhcpcd.enable = false;
@@ -48,7 +52,6 @@
     LC_TIME = "en_GB.UTF-8";
   };
 
-  # Define a user account. Don't forget to set a password with ‘passwd’.
   users = {
     users."${vars.username}" = {
       isNormalUser = true;
@@ -63,8 +66,6 @@
         "gamemode"
         "sops"
       ];
-      #   packages = with pkgs; [    ];
-      #   USER PKGS MANAGED IN HOME.NIX
       shell = pkgs.zsh;
       hashedPasswordFile = config.sops.secrets."system/gibson_user_pass".path;
     };

--- a/profiles/system/server.nix
+++ b/profiles/system/server.nix
@@ -1,0 +1,10 @@
+{
+  inputs,
+  ...
+}:
+{
+  imports = [
+    inputs.self.modules.nixos.attic-server
+    inputs.self.modules.nixos.tailscale
+  ];
+}


### PR DESCRIPTION
Why: Adds in my dedicated binary cache reachable over the LAN and
  Tailscale (for CI), deployed without ever giving the host itself access
  to secrets/sops-nix.

What:
- bump nix-secrets flake input to allow access to the attic server token
- add hosts/attic (proxmox LXC, static LAN IP, SSH locked to main
  machines) and flake/hosts/attic.nix wiring it into the main flake
- add features/attic-server (atticd service, pinned uid/gid for NFS
  mounts, LAN allowlist for :8080) and wire it plus tailscale into the
  new profiles/system/server.nix
- introduce a "nixos-minimal" host type in registry.nix/nixos.nix that
  skips inclusion of sops-nix and home-manager entirely
- add bootstrap/deploy-attic.sh to enable deployment/updating of the
  server from main machines
- retain NIX_SSHOPTS through gibson's sudo-wrapped nixos-rebuild
  alias via security.sudo.extraConfig
