### PR TITLE
docs: update readme with attic host, deploy script, wording fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,21 @@
 
 Welcome to my NixOS config repo.
 
-This contains a personal Nix flake for managing both NixOS and macOS (nix-darwin) systems. Previously handled via dotfiles and stow.
+This contains a personal Nix flake for managing both NixOS and macOS (nix-darwin) system types, and any server builds I may wish to add.
 
 ![screenshot](screenshot.jpeg)
 
-The repo is public as a rebuild reference for myself, and in case anything here is useful to someone else stumbling across it. It won't work out of the box for anyone — it's built around my hardware, my YubiKey, and a private secrets repo. PR requests wont be taken, but feel free to use any code in the repo as you see fit in your own Nix-based projects!
+The repo is public as a rebuild reference for myself, and in case anything here is useful to someone else stumbling across it. It won't work out of the box for anyone — it's built around my hardware, with anything sensitive locked behind YubiKey, and a private secrets repo. 3rd Party PR requests wont be taken, but feel free to use any code in the repo as you see fit in your own Nix-based projects!
 
 ---
 
 ## Hosts
 
-| Host | Platform | System |
-|---|---|---|
-| `gibson` | NixOS | x86_64-linux |
-| `macbook` | nix-darwin | aarch64-darwin |
+| Host | Platform | System | Description |
+|---|---|---|---|
+| `gibson` | NixOS | x86_64-linux | Main NixOS PC |
+| `attic` | NixOS | x86_64-linux | Attic Cache under Proxmox PCT |
+| `macbook` | nix-darwin | aarch64-darwin | M2 Macbook Air |
 
 ---
 
@@ -33,16 +34,17 @@ The repo is public as a rebuild reference for myself, and in case anything here 
 ├── profiles/                  # Profile compositions — groups of features per host class
 ├── pkgs/                      # Custom packages
 └── bootstrap/
-    └── install.sh             # Fresh install bootstrap
+    └── install.sh             # Bootstrap entrypoint; use with --help for assistance
+    └── deploy-attic.sh        # Attic-specific deployment script
 ```
 
-The config follows the [dendritic pattern](https://flake.parts/options/import-tree.html) — features are small, self-contained modules composed into hosts via profiles rather than monolithic per-host config files. [flake-parts](https://github.com/hercules-ci/flake-parts) and [import-tree](https://github.com/vic/import-tree) handle the wiring.
+The config follows the [dendritic pattern](https://saylesss88.github.io/flakes/dendritic_flake_parts.html) — features are small, self-contained modules composed into hosts via profiles rather than monolithic per-host config files. [flake-parts](https://github.com/hercules-ci/flake-parts) and [import-tree](https://github.com/vic/import-tree) handle the wiring.
 
 ---
 
 ## Secrets
 
-Nothing sensitive lives here. Secrets are managed via [sops-nix](https://github.com/Mic92/sops-nix) + `age`, sourced from a private `nix-secrets` repo. The age identity is encrypted to a YubiKey (PIV, via `age-plugin-yubikey`), which is also the root of trust for SSH and GPG. The bootstrap script handles cloning secrets and placing the decrypted age key on a fresh system — see `bootstrap/install.sh --help`.
+Nothing sensitive lives here. Secrets are managed via [sops-nix](https://github.com/Mic92/sops-nix) + `age`, sourced from a private `nix-secrets` repo. The age identity is encrypted to a YubiKey (PIV, via `age-plugin-yubikey`), which is also the root of trust for SSH and GPG. The bootstrap script handles cloning secrets and placing the decrypted age key on a fresh system that has a valid hardware key — see `bootstrap/install.sh --help`.
 
 ---
 


### PR DESCRIPTION
Why: the hosts table, directory tree, and wording were stale after
  adding the attic host and its deploy script, and needed minor
  clarifications around hardware-key security and doc links.

What:
- add attic host row and a description column to the hosts table
- document bootstrap/deploy-attic.sh and the install.sh --help hint
- fix the dendritic pattern reference link
- clarify hardware-key wording in the intro and secrets sections
