### PR TITLE
fix(bootstrap): quote heredocs in usage output to prevent expansion

### DIFF
--- a/bootstrap/common.sh
+++ b/bootstrap/common.sh
@@ -67,7 +67,7 @@ arg_defaults() {
 # Usage preamble — callers append platform-specific sections
 # ---------------------------------------------------------------------------
 usage_common() {
-  cat <<EOF
+  cat <<'EOF'
 Usage: bootstrap/${SCRIPT_NAME} [OPTIONS]
 
 Shared options:

--- a/bootstrap/install-darwin.sh
+++ b/bootstrap/install-darwin.sh
@@ -73,7 +73,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 # ---------------------------------------------------------------------------
 usage() {
   usage_common
-  cat <<EOF
+  cat <<'EOF'
 
 Darwin notes:
   TARGET is always / on macOS — there is no install-time mountpoint.


### PR DESCRIPTION
Why: common_usage() and install-darwin's usage() used unquoted `<<EOF`
heredocs, so backticks and `$VAR`-like tokens in the help text (e.g.
TARGET, paths) were subject to shell expansion instead of being
printed literally.

What:
- quote the heredoc delimiter (`<<'EOF'`) in common.sh's
  usage_common
- quote the heredoc delimiter (`<<'EOF'`) in install-darwin.sh's
  usage
