### PR TITLE
fix(macbook): use hostname arg instead of hardcoded value

### DIFF
--- a/hosts/macbook/system.nix
+++ b/hosts/macbook/system.nix
@@ -1,14 +1,12 @@
-# Edit this configuration file to define what should be installed on
-# your system. Help is available in the configuration.nix(5) man page, on
-# https://search.nixos.org/options and in the NixOS manual (`nixos-help`).
 {
   pkgs,
   vars,
+  hostname,
   ...
 }:
 {
 
-  networking.hostName = "macbook"; # Define your hostname.
+  networking.hostName = hostname;
 
   nix = {
     enable = false;


### PR DESCRIPTION
Why: networking.hostName was hardcoded to "macbook", diverging
from the module's own hostname arg convention used elsewhere.

What:
- add hostname to function args
- set networking.hostName from hostname instead of a literal string

Notes: This should probably be a shared module but it feels overkill
just for one setting..
