### PR TITLE
fix(macbook): remove redundant openssh disable setting

### DIFF
--- a/hosts/macbook/system.nix
+++ b/hosts/macbook/system.nix
@@ -17,8 +17,6 @@
     shell = pkgs.zsh;
   };
 
-  services.openssh.enable = false;
-
   system = {
     stateVersion = 5;
     primaryUser = "${vars.username}";


### PR DESCRIPTION
Why: openssh is already disabled by default on darwin, making this
  explicit override irrelevant

What:
- drop `services.openssh.enable = false;` from hosts/macbook/system.nix
