### PR TITLE
fix(gibson): set explicit pointer cursor theme name

### DIFF
--- a/hosts/gibson/home.nix
+++ b/hosts/gibson/home.nix
@@ -13,7 +13,10 @@
   home = {
     homeDirectory = "/home/${vars.username}";
 
-    pointerCursor.enable = true;
+    pointerCursor = {
+      enable = true;
+      name = "Bibata-Modern-Classic";
+    };
 
     sessionVariables = {
       NIXOS_OZONE_WL = 1;


### PR DESCRIPTION
Why: pointerCursor.enable alone left the cursor theme unset,
falling back to a default/mismatched cursor rather than the
intended theme. This is currently breaking weekly CI runs.

What:
- convert pointerCursor to an attrset
- add name = "Bibata-Modern-Classic"

Notes: requires the Bibata-Modern-Classic cursor theme package
to be available/installed for gibson's home-manager profile.
