### PR TITLE
fix(hosts): use default cursor theme and disable on macbook

### DIFF
--- a/hosts/gibson/home.nix
+++ b/hosts/gibson/home.nix
@@ -13,10 +13,7 @@
   home = {
     homeDirectory = "/home/${vars.username}";
 
-    pointerCursor = {
-      enable = true;
-      name = "Bibata-Modern-Classic";
-    };
+    pointerCursor.enable = true;
 
     sessionVariables = {
       NIXOS_OZONE_WL = 1;

--- a/hosts/macbook/home.nix
+++ b/hosts/macbook/home.nix
@@ -8,6 +8,8 @@
   home = {
     homeDirectory = "/Users/${vars.username}";
 
+    pointerCursor.enable = false;
+
     sessionVariables = {
     };
 


### PR DESCRIPTION
Why: Unbuggering this weeks CI/CD runs

What:
- Remove gibson pointerCursor to just enable, dropping the
  explicit Bibata-Modern-Classic name override; this was a red herring I
  think
- explicitly disable pointerCursor on macbook as thats the real problem
