### PR TITLE
fix(bootstrap): support deploying attic from macOS host

### DIFF
--- a/bootstrap/deploy-attic.sh
+++ b/bootstrap/deploy-attic.sh
@@ -43,5 +43,14 @@ SSH_OPTS=($NIX_SSHOPTS)
 echo "==> pushing atticd env to ${TARGET}"
 sops --decrypt --extract '["services"]["attic"]["server-token"]' "$SECRETS_FILE" \
   | ssh "${SSH_OPTS[@]}" "$TARGET" 'install -m 0600 /dev/stdin /var/lib/attic/env'
+EXTRA_REBUILD_ARGS=()
+if [ "$(uname -s)" = "Darwin" ]; then
+  # macOS can't build or execute x86_64-linux directly: --fast skips
+  # nixos-rebuild's default self-reexec-for-target-platform step (which is
+  # exactly what fails on macOS), and --build-host delegates the actual
+  # build to attic itself. Evaluation still happens locally either way —
+  # only the build step moves, so this doesn't give attic any new access.
+  EXTRA_REBUILD_ARGS+=(--fast --build-host "$TARGET")
+fi
 echo "==> building + switching .#attic on ${TARGET}"
-nixos-rebuild switch --flake ".#attic" --target-host "$TARGET"
+nixos-rebuild switch --flake ".#attic" --target-host "$TARGET" "${EXTRA_REBUILD_ARGS[@]}"

--- a/hosts/macbook/system.nix
+++ b/hosts/macbook/system.nix
@@ -17,6 +17,10 @@
     shell = pkgs.zsh;
   };
 
+  environment.systemPackages = with pkgs; [
+    nixos-rebuild
+  ];
+
   system = {
     stateVersion = 5;
     primaryUser = "${vars.username}";


### PR DESCRIPTION
Why: nixos-rebuild on macOS can't build or exec x86_64-linux
directly, so deploying the attic host from a macbook failed
before it could switch.

What:
- add --fast --build-host fallback in deploy-attic.sh when
  running on Darwin, delegating the build to the target
- install nixos-rebuild on the macbook so the script has it
  available locally

Notes: evaluation still happens locally on macOS either way;
only the build step moves to the target, so this doesn't grant
attic any new access.
