### PR TITLE
fix(bootstrap): use --no-reexec instead of --fast for attic deploy

### DIFF
--- a/bootstrap/deploy-attic.sh
+++ b/bootstrap/deploy-attic.sh
@@ -50,7 +50,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
   # exactly what fails on macOS), and --build-host delegates the actual
   # build to attic itself. Evaluation still happens locally either way —
   # only the build step moves, so this doesn't give attic any new access.
-  EXTRA_REBUILD_ARGS+=(--fast --build-host "$TARGET")
+  EXTRA_REBUILD_ARGS+=(--no-reexec --build-host "$TARGET")
 fi
 echo "==> building + switching .#attic on ${TARGET}"
 nixos-rebuild switch --flake ".#attic" --target-host "$TARGET" "${EXTRA_REBUILD_ARGS[@]}"


### PR DESCRIPTION
Why: --fast doesn't skip nixos-rebuild's self-reexec-for-target-platform
     step. The actual cause of the macOS build failure fixed in
     #340 but --no-reexec is the flag that actually skips it.

What:
- -swap --fast for --no-reexec in EXTRA_REBUILD_ARGS on Darwin

Notes: This was also being flagged as a deprecation warning
