### PR TITLE
feat(zabbix-agent): add shared module and enable on thevault

### DIFF
--- a/features/zabbix-agent/_module.nix
+++ b/features/zabbix-agent/_module.nix
@@ -1,0 +1,32 @@
+{ pkgs, ... }:
+{
+  # Hostname is deliberately NOT set here — it has to match a host's existing
+  # Zabbix inventory entry exactly (case, domain suffix and all), which this
+  # shared module has no way to know. Each host sets it via
+  # services.zabbixAgent.settings.Hostname on top of this.
+  services.zabbixAgent = {
+    enable = true;
+    package = pkgs.zabbix70.agent2;
+    server = "192.168.1.3";
+    settings = {
+      LogFile = "/var/log/zabbix/zabbix_agent2.log";
+      ServerActive = "192.168.1.3";
+      PluginSocket = "/run/zabbix/agent.plugin.sock";
+      ControlSocket = "/run/zabbix/zabbix_agent2.sock";
+      Include = "/etc/zabbix/zabbix_agent2.d/plugins.d/*.conf";
+    };
+  };
+
+  # To ensure the plugins directory above exists
+  systemd.tmpfiles.rules = [
+    "d /etc/zabbix/zabbix_agent2.d/plugins.d 0755 root root -"
+    "d /run/zabbix 0755 zabbix-agent zabbix-agent -"
+  ];
+
+  networking.firewall.extraCommands = ''
+    iptables -A nixos-fw -p tcp -s 192.168.1.3 --dport 10050 -j ACCEPT
+  '';
+  networking.firewall.extraStopCommands = ''
+    iptables -D nixos-fw -p tcp -s 192.168.1.3 --dport 10050 -j ACCEPT || true
+  '';
+}

--- a/features/zabbix-agent/default.nix
+++ b/features/zabbix-agent/default.nix
@@ -1,0 +1,3 @@
+_: {
+  flake.modules.nixos.zabbix-agent = ./_module.nix;
+}

--- a/flake/hosts/servers/thevault.nix
+++ b/flake/hosts/servers/thevault.nix
@@ -9,10 +9,6 @@ let
   path = ./../../../hosts/servers/thevault;
 in
 rec {
-  # No home-manager, no sops-nix, no YubiKey — see registry.nix for what
-  # this kind skips. Stage 1: base host only, no vaultwarden profile yet —
-  # that's added in profiles/system/vaultwarden.nix once features/vaultwarden
-  # exists (Stage 2).
   kind = "nixos-minimal";
   inherit hostname system path;
 
@@ -22,6 +18,7 @@ rec {
   systemProfiles = [
     ./../../../profiles/system/nixos.nix
     ./../../../profiles/system/vaultwarden.nix
+    ./../../../profiles/system/zabbix-agent.nix
   ];
 
   modules = [

--- a/hosts/servers/thevault/system.nix
+++ b/hosts/servers/thevault/system.nix
@@ -40,22 +40,24 @@
     ];
   };
 
-  services.resolved.enable = true;
-
   proxmoxLXC = {
     manageNetwork = false;
     privileged = false;
     manageHostName = true;
   };
 
-  services.openssh = {
-    enable = true;
-    openFirewall = false;
-    settings = {
-      PasswordAuthentication = false;
-      KbdInteractiveAuthentication = false;
-      PermitRootLogin = "prohibit-password";
+  services = {
+    openssh = {
+      enable = true;
+      openFirewall = false;
+      settings = {
+        PasswordAuthentication = false;
+        KbdInteractiveAuthentication = false;
+        PermitRootLogin = "prohibit-password";
+      };
     };
+    resolved.enable = true;
+    zabbixAgent.settings.Hostname = "theVault.home.arpa";
   };
 
   # Standard LAN ssh allow list

--- a/profiles/system/zabbix-agent.nix
+++ b/profiles/system/zabbix-agent.nix
@@ -1,0 +1,9 @@
+{
+  inputs,
+  ...
+}:
+{
+  imports = [
+    inputs.self.modules.nixos.zabbix-agent
+  ];
+}


### PR DESCRIPTION
Why: thevault needs Zabbix monitoring, and a shared feature module
lets future hosts opt in without duplicating agent config.

What:
- add features/zabbix-agent with default agent2 settings (server,
  sockets, plugin include path) wired via flake.modules.nixos
- add profiles/system/zabbix-agent.nix to import the module
- enable the profile on thevault and set its inventory hostname
- group thevault's services under one attrset and drop the stale
  staging-image comment left over from the vaultwarden bootstrap
