### PR TITLE
refactor(vaultwarden): make mkResticBackup a full backup module

### DIFF
--- a/features/vaultwarden/_module.nix
+++ b/features/vaultwarden/_module.nix
@@ -4,6 +4,31 @@
   ...
 }:
 {
+  imports = [
+    (repoLib.mkResticBackup {
+      name = "vaultwarden";
+      paths = [
+        "/var/lib/vaultwarden/backup/db.sqlite3"
+        "/var/lib/vaultwarden/rsa_key.pem"
+        "/var/lib/vaultwarden/rsa_key.pub.pem"
+        "/var/lib/vaultwarden/attachments"
+        "/var/lib/vaultwarden/sends"
+      ];
+      repository = "sftp:networkBackup@backupServer.home.arpa:Linux/bitwarden";
+      passwordFile = "/var/lib/vaultwarden-secrets/restic-password";
+      extraOptions = [
+        "sftp.command='ssh networkBackup@backupServer.home.arpa -i /var/lib/vaultwarden-secrets/restic-sftp-key -s sftp'"
+      ];
+      extraBackupArgs = [
+        "--tag nix"
+      ];
+      backupPrepareCommand = ''
+        mkdir -p /var/lib/vaultwarden/backup
+        ${pkgs.sqlite}/bin/sqlite3 /var/lib/vaultwarden/db.sqlite3 ".backup '/var/lib/vaultwarden/backup/db.sqlite3'"
+      '';
+    })
+  ];
+
   # Vaultwarden's secret env file (ADMIN_TOKEN, YUBICO_SECRET_KEY) lives at
   # /var/lib/vaultwarden-secrets/env, a plain root:root 0600 file outside
   # the Nix store — delivered by bootstrap/deploy-vaultwarden.sh from
@@ -46,47 +71,9 @@
     };
   };
 
-  services.restic.backups.vaultwarden = repoLib.mkResticBackup {
-    paths = [
-      "/var/lib/vaultwarden/backup/db.sqlite3"
-      "/var/lib/vaultwarden/rsa_key.pem"
-      "/var/lib/vaultwarden/rsa_key.pub.pem"
-      "/var/lib/vaultwarden/attachments"
-      "/var/lib/vaultwarden/sends"
-    ];
-    repository = "sftp:networkBackup@backupServer.home.arpa:Linux/bitwarden";
-    passwordFile = "/var/lib/vaultwarden-secrets/restic-password";
-    extraOptions = [
-      "sftp.command='ssh networkBackup@backupServer.home.arpa -i /var/lib/vaultwarden-secrets/restic-sftp-key -s sftp'"
-    ];
-    backupPrepareCommand = ''
-      mkdir -p /var/lib/vaultwarden/backup
-      ${pkgs.sqlite}/bin/sqlite3 /var/lib/vaultwarden/db.sqlite3 ".backup '/var/lib/vaultwarden/backup/db.sqlite3'"
-      : > /var/log/restic_backup_local.log
-    '';
-  };
-
-  # /var/lib/vaultwarden-secrets must exist before push_secrets' `install`
-  # can write into it on a fresh host — declared here rather than left to
-  # an undocumented manual mkdir before the first deploy.
-  systemd = {
-    tmpfiles.rules = [
-      "d /var/lib/vaultwarden-secrets 0700 root root -"
-      "f /var/log/restic_backup_local.log 0644 root root -"
-    ];
-    services = {
-      restic-backups-vaultwarden.onFailure = [
-        "restic-backup-failure-vaultwarden.service"
-      ];
-      restic-backup-failure-vaultwarden = {
-        description = "Records restic backup failure for Zabbix monitoring";
-        serviceConfig.Type = "oneshot";
-        script = ''
-          echo "local failure" > /var/log/restic_backup_local.log
-        '';
-      };
-    };
-  };
+  systemd.tmpfiles.rules = [
+    "d /var/lib/vaultwarden-secrets 0700 root root -"
+  ];
 
   environment.systemPackages = [
     pkgs.vaultwarden # for `vaultwarden hash` if the admin token ever needs regenerating

--- a/flake/parts/hosts/registry.nix
+++ b/flake/parts/hosts/registry.nix
@@ -139,13 +139,15 @@ in
 
       mkResticBackup =
         {
+          name,
           paths,
           repository,
           passwordFile,
-          backupPrepareCommand ? null,
           extraOptions ? [ ],
+          extraBackupArgs ? [ ],
+          backupPrepareCommand ? null,
           timerConfig ? {
-            OnCalendar = "03:00";
+            OnCalendar = "2:30";
           },
           pruneOpts ? [
             "--keep-daily 7"
@@ -153,17 +155,48 @@ in
             "--keep-monthly 6"
           ],
         }:
+        let
+          statusFile = "/var/log/restic_backup_local.log";
+        in
         {
-          inherit
-            paths
-            repository
-            passwordFile
-            extraOptions
-            timerConfig
-            pruneOpts
-            ;
-        }
-        // lib.optionalAttrs (backupPrepareCommand != null) { inherit backupPrepareCommand; };
+          services.restic.backups.${name} = {
+            inherit
+              paths
+              repository
+              passwordFile
+              extraOptions
+              extraBackupArgs
+              timerConfig
+              pruneOpts
+              ;
+            # Status file truncated first, before any caller-supplied
+            # prepare step — if that step itself fails, onFailure below
+            # still fires and overwrites with "local failure" regardless,
+            # but truncating first keeps the intent readable: this run's
+            # status starts clean before anything else happens.
+            backupPrepareCommand =
+              ": > ${statusFile}"
+              + lib.optionalString (backupPrepareCommand != null) ("\n" + backupPrepareCommand);
+          };
+
+          systemd = {
+            tmpfiles.rules = [
+              "f /var/log/restic_backup_local.log 0644 root root -"
+            ];
+            services = {
+              "restic-backups-${name}".onFailure = [
+                "restic-backup-failure-${name}.service"
+              ];
+              "restic-backup-failure-${name}" = {
+                description = "Records restic backup failure for Zabbix monitoring (${name})";
+                serviceConfig.Type = "oneshot";
+                script = ''
+                  echo "local failure" > ${statusFile}
+                '';
+              };
+            };
+          };
+        };
     };
 
     repo.hosts = import ../../hosts {


### PR DESCRIPTION
Why: mkResticBackup only returned the restic.backups attrset, so
every caller had to hand-wire tmpfiles rules and the onFailure ->
zabbix-log service itself, leaving that wiring duplicated instead of
reused.

What:
- mkResticBackup now takes a `name` and returns a full module
  (services.restic.backups.${name} plus its tmpfiles rule and
  onFailure service), keyed by name so it can be reused across
  hosts/backups
- add extraBackupArgs passthrough to the restic backup command
- vaultwarden module now imports mkResticBackup instead of wiring
  services.restic.backups and the systemd services directly
