### PR TITLE
fix(overlays): support tracking multiple PRs per repo entry

### DIFF
--- a/.github/workflows/audit-overlays.yaml
+++ b/.github/workflows/audit-overlays.yaml
@@ -318,7 +318,7 @@ jobs:
                   issue_output=""
                   rc=0
                   issue_output=$(check_github_items "$items_json" "issue") || rc=$?
-                  summary=$(echo "$issue_output" | paste -sd ', ')
+                  summary=$(echo "$issue_output" | paste -sd ',' | sed 's/,/, /g')
                   if [ $rc -eq 0 ]; then
                     is_obsolete=true
                     REPORT_LINES+=("✅ **${host_key} / ${id}**: all tracking issues closed — ${summary}")
@@ -327,11 +327,11 @@ jobs:
                   fi
                   ;;
                 nixpkgs-pr)
-                  items_json=$(echo "$entry" | jq -c '.trackingPRs')
+                  items_json=$(echo "$entry" | jq -c '[.trackingPRs[] | .repo as $r | .numbers[] | {repo: $r, number: .}]')
                   pr_output=""
                   rc=0
                   pr_output=$(check_github_items "$items_json" "pull") || rc=$?
-                  summary=$(echo "$pr_output" | paste -sd ', ')
+                  summary=$(echo "$pr_output" | paste -sd ',' | sed 's/,/, /g')
                   if [ $rc -eq 0 ]; then
                     is_obsolete=true
                     REPORT_LINES+=("✅ **${host_key} / ${id}**: all tracking PRs merged — ${summary}")

--- a/features/system-core/overlays/_overlay-entries.nix
+++ b/features/system-core/overlays/_overlay-entries.nix
@@ -29,7 +29,7 @@
         trackingPRs = [
           {
             repo = "qutebrowser/qutebrowser";
-            number = 8642;
+            numbers = [ 8642 ];
           }
         ];
       };

--- a/flake/parts/exports/overlay-audits.nix
+++ b/flake/parts/exports/overlay-audits.nix
@@ -206,12 +206,12 @@ in
                 lib.types.submodule {
                   options = {
                     repo = lib.mkOption { type = lib.types.str; };
-                    number = lib.mkOption { type = lib.types.int; };
+                    numbers = lib.mkOption { type = lib.types.listOf lib.types.int; };
                   };
                 }
               );
               default = [ ];
-              description = "GitHub PRs that must ALL be merged (nixpkgs-pr only).";
+              description = "GitHub PRs that must ALL be merged, grouped by repo.";
             };
 
             notes = lib.mkOption {

--- a/hosts/personal/macbook/overlays/overlay-entries.nix
+++ b/hosts/personal/macbook/overlays/overlay-entries.nix
@@ -27,7 +27,11 @@ in
         trackingPRs = [
           {
             repo = "NixOS/nixpkgs";
-            number = 515997;
+            numbers = [
+              515997
+              520445
+              547302
+            ];
           }
         ];
         notes = "COUPLED REMOVAL: also remove qtwebengine-fix flake input from flake.nix and the qtPinnedPkgs let-binding in hosts/macbook/overlays/overlay-entries.nix.";


### PR DESCRIPTION
Why: Coupled overlay removals can depend on more than one
  upstream PR per repo, but trackingPRs only allowed a single
  number per entry, so additional PRs couldn't be tracked.

What:
- rename trackingPRs `number` option to `numbers` (list of int) in
  overlay-audits.nix module
- update audit-overlays workflow to flatten repo/numbers pairs into
  individual repo+number check items
- update qutebrowser and macbook qtwebengine-fix entries to use
  the `numbers` list
- fix issue/PR summary formatting in the workflow to space out
  comma-separated items instead of leaving them jammed together
