### PR TITLE
refactor(flake): use imports list for import-tree module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,13 +65,11 @@
 
   outputs =
     inputs@{ flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } (
-      {
-        systems = [
-          "x86_64-linux"
-          "aarch64-darwin"
-        ];
-      }
-      // (inputs.import-tree ./flake/parts)
-    );
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
+      imports = [ (inputs.import-tree ./flake/parts) ];
+    };
 }


### PR DESCRIPTION
Why: mkFlake's config was built by merging the systems attrset
with import-tree's output via `//`, which is a fragile way to
combine flake-parts modules and could silently clobber keys. Upstream
changes also makes it so that the old implementation breaks CI runs.

What:
- switch to passing inputs.import-tree ./flake/parts through the
  standard `imports` list instead of merging with `//`
- keep the systems list as a plain attribute alongside imports

Notes: flake-parts modules should be composed via `imports`, not
merged as raw attrsets, so this matches the idiomatic pattern. This was
a mistake waiting to happen.
