### PR TITLE
fix(ci): checkout correct sha in audit-overlays workflow

### DIFF
--- a/.github/workflows/audit-overlays.yaml
+++ b/.github/workflows/audit-overlays.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@527f17dd63d2d60d3e5552934bc84b9a33a14d11


### PR DESCRIPTION
Why: the audit-overlays job runs on workflow_run, where
  actions/checkout defaults to the main branch instead of the
  branch that triggered the originating workflow run. This ensures that
  overlay audits are based on the current weekly flake lock update
  rather than the previous weeks.

What:
- pin checkout ref to the triggering workflow_run head_sha, falling
  back to github.sha

Notes: keeps the fallback so manual/other trigger types still checkout
  the expected commit
